### PR TITLE
Updated flake.nix, cleaning it up and ensuring it works

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
 
           postInstall = ''
             wrapProgram $out/bin/youtube-tui \
-              --prefix PATH : ${nixpkgs.lib.makeBinPath [ pkgs.mpv pkgs.libsixel ]}
+              --prefix PATH : ${nixpkgs.lib.makeBinPath [ pkgs.mpv ]}
           '';
         };
       in {

--- a/flake.nix
+++ b/flake.nix
@@ -6,47 +6,62 @@
   };
 
   outputs = {
-    self,
     nixpkgs,
     flake-utils,
     rust-overlay,
     ...
   }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      overlays = [(import rust-overlay)];
-      pkgs = import nixpkgs {inherit system overlays;};
-      rustVersion = pkgs.rust-bin.stable.latest.default;
-      toml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [(import rust-overlay)];
+        pkgs = import nixpkgs {inherit system overlays;};
+        rustVersion = pkgs.rust-bin.stable.latest.default;
+        toml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
 
-      rustPlatform = pkgs.makeRustPlatform {
-        cargo = rustVersion;
-        rustc = rustVersion;
-      };
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = rustVersion;
+          rustc = rustVersion;
+        };
 
-      youtube-tui = rustPlatform.buildRustPackage {
-        pname =
-          toml.package.name; # make this what ever your cargo.toml package.name is
-        version = "v${toml.package.version}";
-        src = ./.; # the folder with the cargo.toml
+        youtube-tui = rustPlatform.buildRustPackage {
+          pname =
+            toml.package.name; # make this what ever your cargo.toml package.name is
+          version = "v${toml.package.version}";
+          src = ./.; # the folder with the cargo.toml
 
-        cargoLock.lockFile = ./Cargo.lock;
+          cargoLock.lockFile = ./Cargo.lock;
 
-        buildInputs = with pkgs; [
-          openssl
-          xorg.libxcb
-          libsixel
-          mpv
-        ];
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            python3
+            makeWrapper
+          ];
 
-        nativeBuildInputs = with pkgs; [
-          pkg-config
-          python3
-        ];
-      };
-    in {
-      defaultPackage = youtube-tui;
-      devShell = pkgs.mkShell {
-        buildInputs = [(rustVersion.override {extensions = ["rust-src"];})];
-      };
-    });
+          buildInputs = with pkgs; [
+            openssl
+            xorg.libxcb
+            mpv
+            libsixel
+          ];
+
+          postInstall = ''
+            wrapProgram $out/bin/youtube-tui \
+              --prefix PATH : ${nixpkgs.lib.makeBinPath [ pkgs.mpv pkgs.libsixel ]}
+          '';
+        };
+      in {
+        defaultPackage = youtube-tui;
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            (rustVersion.override {extensions = ["rust-src"];})
+            pkgs.pkg-config
+            pkgs.python3
+            pkgs.openssl
+            pkgs.mpv
+            pkgs.libsixel
+            pkgs.xorg.libxcb
+          ];
+        };
+      }
+    );
 }


### PR DESCRIPTION
Cleaned up and updated `flake.nix`. A wrapper is now used to include `mpv` in the path of the package which allows it to be accessed and videos to actually be played.
The dev shell is also updated to include all the required dependencies.
Also, the `self` dependency is removed for conciseness.