### PR TITLE
fix: put cursor on play video by default instead of reload updated video

### DIFF
--- a/src/items/singleitem.rs
+++ b/src/items/singleitem.rs
@@ -74,15 +74,21 @@ impl SingleVideoItem {
     }
 
     pub fn new_with_map(commands: Vec<(String, String)>) -> Self {
+        let mut textlist = TextList::default()
+            .items(
+                &commands
+                    .iter()
+                    .map(|command| &command.0)
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+        
+        if commands.len() > 1 {
+            let _ = textlist.down();
+        }
+        
         Self {
-            textlist: TextList::default()
-                .items(
-                    &commands
-                        .iter()
-                        .map(|command| &command.0)
-                        .collect::<Vec<_>>(),
-                )
-                .unwrap(),
+            textlist,
             commands,
         }
     }


### PR DESCRIPTION
- This changes the default cursor position on video pages from "Reload updated video" to "Play video" to improve UX.
- After we click on a video from the search results, 99% of the time this means we want to watch the video but by default the cursor was positioned on reload updated video which meant the user would have to scroll down to reach the play video option.
- By making the default cursor position over play video, users can select a video from the list and play it by just pressing Enter twice in succession instead of having to scroll first, reducing friction in the experience.