### PR TITLE
Fix a typo on the help page

### DIFF
--- a/src/global/functions/run_command.rs
+++ b/src/global/functions/run_command.rs
@@ -713,7 +713,7 @@ fn help_msg(cmdefines: &CommandsRemapConfig) -> String {
     \x1b[33mparrun [command]\x1b[0m                Runs a system command non blocking (e.g. `run firefox example.com`)
     \x1b[33mcopy [text]\x1b[0m                     Copies text to clipboard
     \x1b[33mkey [keycode] [keymodifier]\x1b[0m     Create a key input event
-    \x1b[33mecho [mode] [message]\x1b[0m           Dispalys a message in message bar, mode: none, success, warn, error, mpv (can be overwritten by mpv player)
+    \x1b[33mecho [mode] [message]\x1b[0m           Displays a message in message bar, mode: none, success, warn, error, mpv (can be overwritten by mpv player)
 
 \x1b[91mLIBRARY:\x1b[0m
     \x1b[33mbookmark [id]\x1b[0m                   Bookmark item with ID (item must be already loaded)


### PR DESCRIPTION
This pull request corrects a minor typo in the description of the command echo.