### PR TITLE
feat(windows): add cross-platform compatibility for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /docs/book
+/mpv-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1033,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1579,6 +1611,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88adfe3a9f3ef1d69c87ce86930246cd80c86be098d5bfd2a7b05962ff1d3a50"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +1998,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -2465,6 +2512,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3787,7 +3845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3797,7 +3855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
  "windows-result 0.1.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3847,7 +3905,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3870,11 +3928,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3888,19 +3955,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3910,9 +3998,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3928,9 +4028,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3940,9 +4052,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4099,6 +4223,7 @@ dependencies = [
  "chrono",
  "clipboard",
  "crossterm 0.29.0",
+ "dirs",
  "dyn-clone",
  "futures",
  "home",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = {version = "1.0", default-features = false, features = ["derive"]}
 crossterm = {version = "0.29", default-features = false, features = ["serde"]}
 viuer = {version = "0.11", default-features = false, optional = true, features = ["print-file"]}
 home = "0.5"
+dirs = "5"
 chrono = {version = "0.4", default-features = false, features = ["clock"]}
 typemap = {version = "0.3", default-features = false}
 tui-additions = {version = "0.4.3", default-features = false, features = ["framework", "widgets"]}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # Overview
 
-Written in Rust, the **YouTube TUI** is a lightweight and user friendly TUI for browsing YouTube content from the terminal. Works out of the box and easily configurable.
+Written in Rust, the **YouTube TUI** is a lightweight and user friendly TUI for browsing YouTube content from the terminal. Works out of the box and easily configurable. Supports Linux and Windows.
 
 ![](./docs/src/images/readme1.png)
 
@@ -23,7 +23,7 @@ It is like an _app launcher_, it launches other programs to do the heavy lifting
 
 ## Customisable
 
-The YouTube TUI can be customised through config files, they are located in `~/.config/youtube-tui` and are in the YAML format.
+The YouTube TUI can be customised through config files, located in `~/.config/youtube-tui` on Linux or `%APPDATA%\youtube-tui` on Windows, in the YAML format.
 
 Here's an example of the config file:
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+fn main() {
+    // On Windows, help the linker find mpv.lib when building with the mpv feature.
+    // Check MPV_LIB_DIR env var, then fall back to a local mpv-dev directory.
+    #[cfg(all(target_os = "windows", feature = "mpv"))]
+    {
+        if let Ok(dir) = std::env::var("MPV_LIB_DIR") {
+            println!("cargo:rustc-link-search=native={}", dir);
+        } else {
+            // Check for a local mpv-dev directory (created by setup-mpv-dev.ps1)
+            let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+            let local_mpv = std::path::Path::new(&manifest_dir).join("mpv-dev");
+            if local_mpv.exists() {
+                println!(
+                    "cargo:rustc-link-search=native={}",
+                    local_mpv.display()
+                );
+            }
+        }
+    }
+}

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-The YouTube TUI is *not* intended for Windows, pull requests to make it work are welcome.
+The YouTube TUI supports both Linux and Windows.
 
 ## Install from Crates.io (recommended)
 
@@ -66,6 +66,33 @@ youtube-tui
 
 If installed correctly, a TUI should be launched. Press `q` to close the TUI.
 
+## Installation on Windows
+
+Install using `cargo`:
+
+```sh
+cargo install youtube-tui
+```
+
+All default features work on Windows. The `sixel` feature uses a pure Rust encoder on Windows (no native dependencies). The `clipboard` feature uses native Windows clipboard APIs.
+
+If you do not have `mpv` installed, you can disable the `mpv` feature:
+
+```sh
+cargo install youtube-tui --no-default-features -F sixel -F halfblock -F clipboard -F rustypipe
+```
+
+### Windows configuration
+
+The default config directory on Windows is `%APPDATA%\youtube-tui\`. Data files (history, thumbnails, etc.) are stored in `%LOCALAPPDATA%\youtube-tui\`.
+
+Default tools on Windows:
+- **Browser**: `explorer` (opens URLs in default browser)
+- **Terminal emulator**: `cmd /c start cmd /k`
+- **Shell**: `cmd`
+
+These can be changed in `main.yml`.
+
 ## Features
 
 The TUI has features that can be enabled/disabled when compiling.
@@ -82,23 +109,21 @@ Display images through HalfBlocks, work best in terminals with TrueColour suppor
 
 ### `sixel` (default)
 
-Display images with Sixels, allows the display of images at full definition. Not present on windows.
+Display images with Sixels, allows the display of images at full definition.
 
-Enabling this will also enable `halfblock`.
-
-Requires <a href="https://github.com/saitoha/libsixel" target=_blank>`libsixel`</a>.
+On Linux, this uses the C `libsixel` library for best performance (requires <a href="https://github.com/saitoha/libsixel" target=_blank>`libsixel`</a>). On Windows, a pure Rust encoder is used automatically (no native dependencies).
 
 ### `clipboard` (default)
 
 Allows clipboard pasting in commands and search bar.
 
-Requires <a href="https://xcb.freedesktop.org/" target=_blank>`libxcb`</a>.
+On Linux, requires <a href="https://xcb.freedesktop.org/" target=_blank>`libxcb`</a>. On Windows, uses native clipboard APIs (no extra dependencies).
 
 ### `mpv` (default)
 
 Embedded audio player
 
-Requires <a href="https://mpv.io/" target=_blank>`mpv`</a> (libmpv) to be installed in your system.
+Requires <a href="https://mpv.io/" target=_blank>`mpv`</a> (libmpv) to be installed in your system. On Windows, `mpv.dll` must be available in your PATH or next to the executable.
 
 ### rustypipe (default)
 

--- a/setup-mpv-dev.ps1
+++ b/setup-mpv-dev.ps1
@@ -1,0 +1,139 @@
+# Downloads mpv dev library for Windows (required to build with the `mpv` feature)
+# Usage: .\setup-mpv-dev.ps1
+# This downloads ~30MB and extracts mpv.lib + libmpv-2.dll into a local 'mpv-dev' folder.
+# Then sets MPV_LIB_DIR for the current session.
+
+$ErrorActionPreference = "Stop"
+
+$mpvDevDir = Join-Path $PSScriptRoot "mpv-dev"
+$mpvLib = Join-Path $mpvDevDir "mpv.lib"
+
+if (Test-Path $mpvLib) {
+    Write-Host "mpv.lib already exists at $mpvDevDir, skipping download."
+    $env:MPV_LIB_DIR = $mpvDevDir
+    Write-Host "MPV_LIB_DIR set to $mpvDevDir"
+    return
+}
+
+# Detect architecture
+$arch = if ([Environment]::Is64BitOperatingSystem) { "x86_64" } else { "i686" }
+$url = "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260412/mpv-dev-${arch}-20260412-git-062f4bf.7z"
+
+Write-Host "Downloading mpv-dev for $arch..."
+$tempFile = Join-Path $env:TEMP "mpv-dev.7z"
+Invoke-WebRequest -Uri $url -OutFile $tempFile -UserAgent "Mozilla/5.0"
+
+# Create output directory
+New-Item -ItemType Directory -Force -Path $mpvDevDir | Out-Null
+
+# Extract using 7z (ships with scoop, git, or can be installed via scoop install 7zip)
+$7zPaths = @(
+    "7z",
+    "$env:ProgramFiles\7-Zip\7z.exe",
+    "$env:LOCALAPPDATA\Programs\7-Zip\7z.exe",
+    "$env:USERPROFILE\scoop\apps\7zip\current\7z.exe"
+)
+
+$7zExe = $null
+foreach ($p in $7zPaths) {
+    if (Get-Command $p -ErrorAction SilentlyContinue) {
+        $7zExe = $p
+        break
+    }
+    if (Test-Path $p) {
+        $7zExe = $p
+        break
+    }
+}
+
+if (-not $7zExe) {
+    Write-Host "7z not found. Attempting to install via scoop..."
+    scoop install 7zip
+    $7zExe = "$env:USERPROFILE\scoop\apps\7zip\current\7z.exe"
+}
+
+Write-Host "Extracting mpv-dev..."
+$tempExtract = Join-Path $env:TEMP "mpv-dev-extract"
+if (Test-Path $tempExtract) { Remove-Item -Recurse -Force $tempExtract }
+& $7zExe x $tempFile -o"$tempExtract" -y | Out-Null
+
+# Copy the files we need
+$libFile = Get-ChildItem -Path $tempExtract -Filter "mpv.lib" -Recurse | Select-Object -First 1
+$dllFile = Get-ChildItem -Path $tempExtract -Filter "libmpv-2.dll" -Recurse | Select-Object -First 1
+
+if (-not $libFile) {
+    # The shinchiro builds ship libmpv.dll.a (GCC format), not mpv.lib (MSVC format).
+    # Generate mpv.lib from the DLL using dumpbin + lib (MSVC tools).
+    Write-Host "mpv.lib not found in archive. Generating from libmpv-2.dll..."
+
+    $dllForLib = Get-ChildItem -Path $tempExtract -Filter "libmpv-2.dll" -Recurse | Select-Object -First 1
+    if (-not $dllForLib) {
+        Write-Error "Could not find libmpv-2.dll in the archive!"
+    }
+
+    # Find MSVC tools (dumpbin, lib) - they're installed but not in PATH
+    $vsBase = "${env:ProgramFiles(x86)}\Microsoft Visual Studio"
+    if (-not (Test-Path $vsBase)) { $vsBase = "$env:ProgramFiles\Microsoft Visual Studio" }
+    $dumpbin = Get-ChildItem -Path $vsBase -Recurse -Filter "dumpbin.exe" -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -like "*Hostx64\x64*" -or $_.FullName -like "*HostX64\x64*" } |
+        Select-Object -First 1 -ExpandProperty FullName
+    $libExe = Get-ChildItem -Path $vsBase -Recurse -Filter "lib.exe" -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -like "*Hostx64\x64*" -or $_.FullName -like "*HostX64\x64*" } |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $dumpbin -or -not $libExe) {
+        Write-Error "Could not find MSVC build tools (dumpbin.exe, lib.exe). Install 'Desktop development with C++' workload."
+    }
+
+    # Export function names from DLL
+    $defPath = Join-Path $mpvDevDir "mpv.def"
+    $exports = & $dumpbin /exports "$($dllForLib.FullName)" 2>&1 |
+        Select-String "^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\S+)" |
+        ForEach-Object { $_.Matches[0].Groups[1].Value }
+
+    # Write .def file
+    $defContent = "LIBRARY libmpv-2`nEXPORTS`n"
+    $defContent += ($exports | ForEach-Object { "    $_" }) -join "`n"
+    Set-Content -Path $defPath -Value $defContent -Encoding ASCII
+
+    # Generate .lib from .def
+    $machine = if ($arch -eq "x86_64") { "x64" } else { "x86" }
+    & $libExe /def:"$defPath" /machine:$machine /out:"$mpvDevDir\mpv.lib" 2>&1 | Out-Null
+
+    if (-not (Test-Path "$mpvDevDir\mpv.lib")) {
+        Write-Error "Failed to generate mpv.lib!"
+    } else {
+        Write-Host "Generated mpv.lib successfully."
+    }
+} else {
+    Copy-Item $libFile.FullName $mpvDevDir
+}
+
+if ($dllFile) {
+    Copy-Item $dllFile.FullName $mpvDevDir
+    # Also copy DLL next to the built binary location
+    $targetRelease = Join-Path $PSScriptRoot "target\release"
+    if (Test-Path $targetRelease) {
+        Copy-Item $dllFile.FullName $targetRelease
+    }
+}
+
+# Also grab any other DLLs we might need
+Get-ChildItem -Path $tempExtract -Filter "*.dll" -Recurse | ForEach-Object {
+    Copy-Item $_.FullName $mpvDevDir -Force
+}
+
+# Cleanup
+Remove-Item -Force $tempFile -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force $tempExtract -ErrorAction SilentlyContinue
+
+$env:MPV_LIB_DIR = $mpvDevDir
+Write-Host ""
+Write-Host "Done! mpv dev files extracted to: $mpvDevDir"
+Write-Host "MPV_LIB_DIR set to: $mpvDevDir"
+Write-Host ""
+Write-Host "You can now build with:"
+Write-Host "  cargo build --release"
+Write-Host ""
+Write-Host "To make this permanent, add to your PowerShell profile:"
+Write-Host "  `$env:MPV_LIB_DIR = '$mpvDevDir'"

--- a/src/config/appearance.rs
+++ b/src/config/appearance.rs
@@ -1,5 +1,4 @@
-use crate::{config::serde::*, global::traits::*};
-use home::home_dir;
+use crate::{config::serde::*, global::functions::paths, global::traits::*};
 use ratatui::{style::Color, widgets::BorderType};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -38,8 +37,8 @@ impl AppearanceConfig {
             return Ok(appearance);
         }
 
-        let config_path = home_dir().unwrap().join(format!(
-            ".config/youtube-tui/{}.{}",
+        let config_path = paths::config_dir().join(format!(
+            "{}.{}",
             AppearanceConfigSerde::LABEL,
             EXTENSION
         ));

--- a/src/config/commandbindings.rs
+++ b/src/config/commandbindings.rs
@@ -161,11 +161,17 @@ fn get_command<'a>(
 
 // default functions
 
+/// Returns the appropriate quote character for shell commands on the current platform.
+#[cfg(target_os = "windows")]
+const Q: &str = "\"";
+#[cfg(not(target_os = "windows"))]
+const Q: &str = "'";
+
 fn global_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
     HashMap::from([
         (
             KeyCodeSerde::Char('f'),
-            HashMap::from([(2, String::from("run ${browser} '${url}'"))]),
+            HashMap::from([(2, format!("run ${{browser}} {Q}${{url}}{Q}"))]),
         ),
         (
             KeyCodeSerde::Char('c'),
@@ -204,9 +210,9 @@ fn global_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
 
 fn search_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
     HashMap::from([
-        (KeyCodeSerde::Char('a'), HashMap::from([(2, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video"))])),
-        (KeyCodeSerde::Char('A'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video --loop-playlist=inf --shuffle"))])),
-        (KeyCodeSerde::Char('p'), HashMap::from([(2, String::from("parrun mpv '${hover-url}'"))])),
+        (KeyCodeSerde::Char('a'), HashMap::from([(2, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video"))])),
+        (KeyCodeSerde::Char('A'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('p'), HashMap::from([(2, format!("parrun mpv {Q}${{hover-url}}{Q}"))])),
     ])
 }
 
@@ -216,41 +222,41 @@ fn channel_main_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
 
 fn channel_playlists_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
     HashMap::from([
-        (KeyCodeSerde::Char('a'), HashMap::from([(2, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video"))])),
-        (KeyCodeSerde::Char('A'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video --loop-playlist=inf --shuffle"))])),
-        (KeyCodeSerde::Char('p'), HashMap::from([(2, String::from("parrun mpv '${hover-url}'"))])),
+        (KeyCodeSerde::Char('a'), HashMap::from([(2, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video"))])),
+        (KeyCodeSerde::Char('A'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('p'), HashMap::from([(2, format!("parrun mpv {Q}${{hover-url}}{Q}"))])),
     ])
 }
 
 fn channel_videos_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
     HashMap::from([
-        (KeyCodeSerde::Char('a'), HashMap::from([(2, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video"))])),
-        (KeyCodeSerde::Char('A'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video --loop-playlist=inf --shuffle"))])),
-        (KeyCodeSerde::Char('p'), HashMap::from([(2, String::from("parrun mpv '${hover-url}'"))])),
+        (KeyCodeSerde::Char('a'), HashMap::from([(2, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video"))])),
+        (KeyCodeSerde::Char('A'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('p'), HashMap::from([(2, format!("parrun mpv {Q}${{hover-url}}{Q}"))])),
     ])
 }
 
 fn playlist_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
     HashMap::from([
-        (KeyCodeSerde::Char('a'), HashMap::from([(2, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video"))])),
-        (KeyCodeSerde::Char('A'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video --loop-playlist=inf --shuffle"))])),
-        (KeyCodeSerde::Char('p'), HashMap::from([(2, String::from("parrun mpv '${hover-url}'"))])),
+        (KeyCodeSerde::Char('a'), HashMap::from([(2, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video"))])),
+        (KeyCodeSerde::Char('A'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('p'), HashMap::from([(2, format!("parrun mpv {Q}${{hover-url}}{Q}"))])),
     ])
 }
 
 fn popular_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
     HashMap::from([
-        (KeyCodeSerde::Char('a'), HashMap::from([(2, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video"))])),
-        (KeyCodeSerde::Char('A'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video --loop-playlist=inf --shuffle"))])),
-        (KeyCodeSerde::Char('p'), HashMap::from([(2, String::from("parrun mpv '${hover-url}'"))])),
+        (KeyCodeSerde::Char('a'), HashMap::from([(2, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video"))])),
+        (KeyCodeSerde::Char('A'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('p'), HashMap::from([(2, format!("parrun mpv {Q}${{hover-url}}{Q}"))])),
     ])
 }
 
 fn trending_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
     HashMap::from([
-        (KeyCodeSerde::Char('a'), HashMap::from([(2, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video"))])),
-        (KeyCodeSerde::Char('A'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video --loop-playlist=inf --shuffle"))])),
-        (KeyCodeSerde::Char('p'), HashMap::from([(2, String::from("parrun mpv '${hover-url}'"))])),
+        (KeyCodeSerde::Char('a'), HashMap::from([(2, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video"))])),
+        (KeyCodeSerde::Char('A'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('p'), HashMap::from([(2, format!("parrun mpv {Q}${{hover-url}}{Q}"))])),
     ])
 }
 
@@ -260,9 +266,9 @@ fn video_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
 
 fn watchhistory_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
     HashMap::from([
-        (KeyCodeSerde::Char('a'), HashMap::from([(2, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video"))])),
-        (KeyCodeSerde::Char('A'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video --loop-playlist=inf --shuffle"))])),
-        (KeyCodeSerde::Char('p'), HashMap::from([(2, String::from("parrun mpv '${hover-url}'"))])),
+        (KeyCodeSerde::Char('a'), HashMap::from([(2, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video"))])),
+        (KeyCodeSerde::Char('A'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('p'), HashMap::from([(2, format!("parrun mpv {Q}${{hover-url}}{Q}"))])),
     ])
 }
 
@@ -272,22 +278,22 @@ fn feed_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
             KeyCodeSerde::Char('a'),
             HashMap::from([(
                 2,
-                String::from("parrun ${terminal-emulator} mpv '${hover-video-url}' --no-video"),
+                format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-video-url}}{Q} --no-video"),
             )]),
         ),
-        (KeyCodeSerde::Char('A'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-channel-url}/videos' --no-video --loop-playlist=inf --shuffle"))])),
-        (KeyCodeSerde::Char('P'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-channel-url}/videos' --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('A'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-channel-url}}/videos{Q} --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('P'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-channel-url}}/videos{Q} --no-video --loop-playlist=inf --shuffle"))])),
         (
             KeyCodeSerde::Char('p'),
-            HashMap::from([(2, String::from("parrun mpv '${hover-video-url}'"))]),
+            HashMap::from([(2, format!("parrun mpv {Q}${{hover-video-url}}{Q}"))]),
         ),
     ])
 }
 
 fn library_default() -> HashMap<KeyCodeSerde, HashMap<u8, String>> {
     HashMap::from([
-        (KeyCodeSerde::Char('a'), HashMap::from([(2, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video"))])),
-        (KeyCodeSerde::Char('A'), HashMap::from([(1, String::from("parrun ${terminal-emulator} mpv '${hover-url}' --no-video --loop-playlist=inf --shuffle"))])),
-        (KeyCodeSerde::Char('p'), HashMap::from([(2, String::from("parrun mpv '${hover-url}'"))])),
+        (KeyCodeSerde::Char('a'), HashMap::from([(2, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video"))])),
+        (KeyCodeSerde::Char('A'), HashMap::from([(1, format!("parrun ${{terminal-emulator}} mpv {Q}${{hover-url}}{Q} --no-video --loop-playlist=inf --shuffle"))])),
+        (KeyCodeSerde::Char('p'), HashMap::from([(2, format!("parrun mpv {Q}${{hover-url}}{Q}"))])),
     ])
 }

--- a/src/config/commands.rs
+++ b/src/config/commands.rs
@@ -98,6 +98,16 @@ fn launch_command_default() -> String {
 }
 
 fn video_default() -> Vec<HashMap<String, String>> {
+    #[cfg(target_os = "windows")]
+    let q = "\"";
+    #[cfg(not(target_os = "windows"))]
+    let q = "'";
+
+    #[cfg(target_os = "windows")]
+    let rm_cmd = |pattern: &str| format!("run cmd /c del /q /s \"{pattern}\"");
+    #[cfg(not(target_os = "windows"))]
+    let rm_cmd = |pattern: &str| format!("run rm -rf '{pattern}'");
+
     vec![
         HashMap::from([(
             String::from("Reload updated video"),
@@ -105,20 +115,16 @@ fn video_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("Play video"),
-            String::from("parrun ${video-player} '${embed-url}'"),
+            format!("parrun ${{video-player}} {q}${{embed-url}}{q}"),
         )]),
         HashMap::from([(
             String::from("Play audio"),
-            String::from("mpv stop ;; resume ;; mpv sprop loop-file no ;; mpv loadfile '${embed-url}' ;; echo mpv Player started"),
+            format!("mpv stop ;; resume ;; mpv sprop loop-file no ;; mpv loadfile {q}${{embed-url}}{q} ;; echo mpv Player started"),
         )]),
         HashMap::from([(
             String::from("Play audio (loop)"),
-            String::from("mpv stop ;; resume ;; mpv sprop loop-file inf ;; mpv loadfile '${embed-url}' ;; echo mpv Player started"),
+            format!("mpv stop ;; resume ;; mpv sprop loop-file inf ;; mpv loadfile {q}${{embed-url}}{q} ;; echo mpv Player started"),
         )]),
-        // HashMap::from([(
-        //     String::from("Add to queue"),
-        //     String::from("mpv loadfile '${embed-url}' appendplay;; echo mpv Added to queue"),
-        // )]),
         HashMap::from([(
             String::from("View channel"),
             String::from("channel ${channel-id}"),
@@ -129,7 +135,7 @@ fn video_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("Open in browser"),
-            String::from("parrun ${browser} '${url}'"),
+            format!("parrun ${{browser}} {q}${{url}}{q}"),
         )]),
         HashMap::from([(
             String::from("Toggle bookmark"),
@@ -137,11 +143,11 @@ fn video_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("Save video to library"),
-            String::from("bookmark ${id} ;; run rm -rf '${save-path}${id}.*' ;; parrun ${terminal-emulator} ${youtube-downloader} '${embed-url}' -o '${save-path}%(title)s[%(id)s].%(ext)s'")
+            format!("bookmark ${{id}} ;; {} ;; parrun ${{terminal-emulator}} ${{youtube-downloader}} {q}${{embed-url}}{q} -o {q}${{save-path}}%(title)s[${{id}}].%(ext)s{q}", rm_cmd("${save-path}${id}.*"))
         )]),
         HashMap::from([(
             String::from("Save audio to library"),
-            String::from("bookmark ${id} ;; parrun rm -rf '${save-path}${id}.*' ;; parrun ${terminal-emulator} ${youtube-downloader} '${embed-url}' -x -o '${save-path}%(title)s[%(id)s].%(ext)s'")
+            format!("bookmark ${{id}} ;; {} ;; parrun ${{terminal-emulator}} ${{youtube-downloader}} {q}${{embed-url}}{q} -x -o {q}${{save-path}}%(title)s[${{id}}].%(ext)s{q}", rm_cmd("${save-path}${id}.*"))
         )]),
         HashMap::from([(
             String::from("Mode: ${provider}"),
@@ -151,6 +157,16 @@ fn video_default() -> Vec<HashMap<String, String>> {
 }
 
 fn saved_video_default() -> Vec<HashMap<String, String>> {
+    #[cfg(target_os = "windows")]
+    let q = "\"";
+    #[cfg(not(target_os = "windows"))]
+    let q = "'";
+
+    #[cfg(target_os = "windows")]
+    let rm_cmd = |pattern: &str| format!("run cmd /c del /q /s \"{pattern}\"");
+    #[cfg(not(target_os = "windows"))]
+    let rm_cmd = |pattern: &str| format!("run rm {pattern}");
+
     vec![
         HashMap::from([(
             String::from("Reload updated video"),
@@ -158,20 +174,16 @@ fn saved_video_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("[Offline] Play saved file"),
-            String::from("parrun ${video-player} '${offline-path}' --force-window"),
+            format!("parrun ${{video-player}} {q}${{offline-path}}{q} --force-window"),
         )]),
         HashMap::from([(
             String::from("[Offline] Play saved file (audio)"),
-            String::from("mpv stop ;; resume ;; mpv sprop loop-file no ;; mpv loadfile '${offline-path}' ;; echo mpv Player started"),
+            format!("mpv stop ;; resume ;; mpv sprop loop-file no ;; mpv loadfile {q}${{offline-path}}{q} ;; echo mpv Player started"),
         )]),
         HashMap::from([(
             String::from("[Offline] Play saved file (audio loop)"),
-            String::from("mpv stop ;; resume ;; mpv sprop loop-file inf ;; mpv loadfile '${offline-path}' ;; echo mpv Player started"),
+            format!("mpv stop ;; resume ;; mpv sprop loop-file inf ;; mpv loadfile {q}${{offline-path}}{q} ;; echo mpv Player started"),
         )]),
-        // HashMap::from([(
-        //     String::from("[Offline] Add to queue"),
-        //     String::from("mpv loadfile '${offline-path}' appendplay ;; echo mpv Added to queue"),
-        // )]),
         HashMap::from([(
             String::from("View channel"),
             String::from("channel ${channel-id}"),
@@ -182,7 +194,7 @@ fn saved_video_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("Open in browser"),
-            String::from("parrun ${browser} '${url}'"),
+            format!("parrun ${{browser}} {q}${{url}}{q}"),
         )]),
         HashMap::from([(
             String::from("Toggle bookmark"),
@@ -190,20 +202,25 @@ fn saved_video_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("Redownload video to library"),
-            String::from("bookmark ${id} ;; run rm ${save-path}*${id}*.* ;; parrun ${terminal-emulator} ${youtube-downloader} ${embed-url} -o '${save-path}%(title)s[%(id)s].%(ext)s'"),
+            format!("bookmark ${{id}} ;; {} ;; parrun ${{terminal-emulator}} ${{youtube-downloader}} ${{embed-url}} -o {q}${{save-path}}%(title)s[${{id}}].%(ext)s{q}", rm_cmd("${save-path}*${id}*.*")),
         )]),
         HashMap::from([(
             String::from("Redownload audio to library"),
-            String::from("bookmark ${id} ;; run rm ${save-path}*${id}*.* ;; parrun ${terminal-emulator} ${youtube-downloader} ${embed-url} -x -o '${save-path}%(title)s[%(id)s].%(ext)s'")
+            format!("bookmark ${{id}} ;; {} ;; parrun ${{terminal-emulator}} ${{youtube-downloader}} ${{embed-url}} -x -o {q}${{save-path}}%(title)s[${{id}}].%(ext)s{q}", rm_cmd("${save-path}*${id}*.*"))
         )]),
         HashMap::from([(
             String::from("Delete saved file"),
-            String::from("run rm ${save-path}*${id}*.*")
+            rm_cmd("${save-path}*${id}*.*")
         )]),
     ]
 }
 
 fn playlist_default() -> Vec<HashMap<String, String>> {
+    #[cfg(target_os = "windows")]
+    let q = "\"";
+    #[cfg(not(target_os = "windows"))]
+    let q = "'";
+
     vec![
         HashMap::from([(String::from("Switch view"), String::from("%switch-view%"))]),
         HashMap::from([(
@@ -222,10 +239,6 @@ fn playlist_default() -> Vec<HashMap<String, String>> {
             String::from("Shuffle play all (audio loop)"),
             String::from("mpv stop ;; resume ;; ${mpv-queuelist} ;; mpv sprop loop-playlist yes ;; mpv playlist-shuffle ;; mpv playlist-play-index 0 ;; echo mpv Player started"),
         )]),
-        // HashMap::from([(
-        //     String::from("Add all to queue"),
-        //     String::from("${mpv-queuelist} ;; echo mpv Queued playlist"),
-        // )]),
         HashMap::from([(
             String::from("View channel"),
             String::from("channel ${channel-id}"),
@@ -236,7 +249,7 @@ fn playlist_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("Open in browser"),
-            String::from("parrun ${browser} '${url}'"),
+            format!("parrun ${{browser}} {q}${{url}}{q}"),
         )]),
         HashMap::from([(
             String::from("Toggle bookmark"),
@@ -244,11 +257,21 @@ fn playlist_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("Save playlist videos to library"),
-            String::from("bookmark ${id} ;; run rm -rf '${save-path}*${id}*' ;; parrun ${terminal-emulator} bash -c \"${youtube-downloader} ${all-videos} -o '\"'${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s'\"'\"")
+            {
+                #[cfg(target_os = "windows")]
+                { String::from("bookmark ${id} ;; run cmd /c rd /s /q \"${save-path}*${id}*\" ;; parrun ${terminal-emulator} ${youtube-downloader} ${all-videos} -o \"${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s\"") }
+                #[cfg(not(target_os = "windows"))]
+                { String::from("bookmark ${id} ;; run rm -rf '${save-path}*${id}*' ;; parrun ${terminal-emulator} bash -c \"${youtube-downloader} ${all-videos} -o '\"'${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s'\"'\"") }
+            }
         )]),
         HashMap::from([(
             String::from("Save playlist audio to library"),
-            String::from("bookmark ${id} ;; run rm -rf '${save-path}*${id}*' ;; parrun ${terminal-emulator} bash -c \"${youtube-downloader} ${all-videos} -x -o '\"'${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s'\"'\"")
+            {
+                #[cfg(target_os = "windows")]
+                { String::from("bookmark ${id} ;; run cmd /c rd /s /q \"${save-path}*${id}*\" ;; parrun ${terminal-emulator} ${youtube-downloader} ${all-videos} -x -o \"${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s\"") }
+                #[cfg(not(target_os = "windows"))]
+                { String::from("bookmark ${id} ;; run rm -rf '${save-path}*${id}*' ;; parrun ${terminal-emulator} bash -c \"${youtube-downloader} ${all-videos} -x -o '\"'${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s'\"'\"") }
+            }
         )]),
         HashMap::from([(
             String::from("Mode: ${provider}"),
@@ -258,6 +281,11 @@ fn playlist_default() -> Vec<HashMap<String, String>> {
 }
 
 fn saved_playlist_default() -> Vec<HashMap<String, String>> {
+    #[cfg(target_os = "windows")]
+    let q = "\"";
+    #[cfg(not(target_os = "windows"))]
+    let q = "'";
+
     vec![
         HashMap::from([(String::from("Switch view"), String::from("%switch-view%"))]),
         HashMap::from([(
@@ -276,10 +304,6 @@ fn saved_playlist_default() -> Vec<HashMap<String, String>> {
             String::from("[Offline] Shuffle play all (audio loop)"),
             String::from("mpv stop ;; resume ;; ${offline-queuelist} ;; mpv sprop loop-playlist yes ;; mpv playlist-shuffle ;; mpv playlist-play-index 0 ;; echo mpv Player started"),
         )]),
-        // HashMap::from([(
-        //     String::from("[Offline] Add all to queue"),
-        //     String::from("${offline-queuelist} ;; echo mpv Queued playlist"),
-        // )]),
         HashMap::from([(
             String::from("View channel"),
             String::from("channel ${channel-id}"),
@@ -290,7 +314,7 @@ fn saved_playlist_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("Open in browser"),
-            String::from("parrun ${browser} '${url}'"),
+            format!("parrun ${{browser}} {q}${{url}}{q}"),
         )]),
         HashMap::from([(
             String::from("Toggle bookmark"),
@@ -298,15 +322,30 @@ fn saved_playlist_default() -> Vec<HashMap<String, String>> {
         )]),
         HashMap::from([(
             String::from("Redownload playlist videos to library"),
-            String::from("bookmark ${id} ;; run rm -rf ${save-path}*${id}* ;; parrun ${terminal-emulator} bash -c \"${youtube-downloader} ${all-videos} -o '\"'${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s'\"'\"")
+            {
+                #[cfg(target_os = "windows")]
+                { String::from("bookmark ${id} ;; run cmd /c rd /s /q \"${save-path}*${id}*\" ;; parrun ${terminal-emulator} ${youtube-downloader} ${all-videos} -o \"${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s\"") }
+                #[cfg(not(target_os = "windows"))]
+                { String::from("bookmark ${id} ;; run rm -rf ${save-path}*${id}* ;; parrun ${terminal-emulator} bash -c \"${youtube-downloader} ${all-videos} -o '\"'${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s'\"'\"") }
+            }
         )]),
         HashMap::from([(
             String::from("Redownload playlist audio to library"),
-            String::from("bookmark ${id} ;; run rm -rf ${save-path}*${id}* ;; parrun ${terminal-emulator} bash -c \"${youtube-downloader} ${all-videos} -x -o '\"'${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s'\"'\"")
+            {
+                #[cfg(target_os = "windows")]
+                { String::from("bookmark ${id} ;; run cmd /c rd /s /q \"${save-path}*${id}*\" ;; parrun ${terminal-emulator} ${youtube-downloader} ${all-videos} -x -o \"${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s\"") }
+                #[cfg(not(target_os = "windows"))]
+                { String::from("bookmark ${id} ;; run rm -rf ${save-path}*${id}* ;; parrun ${terminal-emulator} bash -c \"${youtube-downloader} ${all-videos} -x -o '\"'${save-path}${title}[${id}]/%(title)s[%(id)s].%(ext)s'\"'\"") }
+            }
         )]),
         HashMap::from([(
             String::from("Delete saved files"),
-            String::from("run rm -rf ${save-path}*${id}*")
+            {
+                #[cfg(target_os = "windows")]
+                { String::from("run cmd /c rd /s /q \"${save-path}*${id}*\"") }
+                #[cfg(not(target_os = "windows"))]
+                { String::from("run rm -rf ${save-path}*${id}*") }
+            }
         )]),
     ]
 }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -3,11 +3,11 @@ use super::{
     WriteConfig,
 };
 use crate::global::{
+    functions::paths,
     structs::KeyAction,
     traits::{ConfigTrait, EXTENSION},
 };
 use crossterm::event::{KeyCode, KeyEvent};
-use home::home_dir;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -174,8 +174,8 @@ impl KeyBindingsConfig {
             return Ok(keybindings);
         }
 
-        let config_path = home_dir().unwrap().join(format!(
-            ".config/youtube-tui/{}.{}",
+        let config_path = paths::config_dir().join(format!(
+            "{}.{}",
             KeyBindingsConfigSerde::LABEL,
             EXTENSION
         ));

--- a/src/config/main.rs
+++ b/src/config/main.rs
@@ -287,27 +287,59 @@ const fn write_to_config_default() -> WriteConfig {
 }
 
 fn default_env() -> HashMap<String, String> {
-    HashMap::from([
-        (String::from("video-player"), String::from("mpv")),
-        (String::from("browser"), String::from("xdg-open")),
-        (
-            String::from("terminal-emulator"),
-            String::from("konsole -e"),
-        ),
-        (String::from("youtube-downloader"), String::from("yt-dlp")),
-        (
-            String::from("download-path"),
-            String::from("~/Downloads/%(title)s-%(id)s.%(ext)s"),
-        ),
-        (
-            String::from("save-path"),
-            String::from("~/.local/share/youtube-tui/saved/"),
-        ),
-    ])
+    use crate::global::functions::paths;
+
+    #[cfg(target_os = "windows")]
+    {
+        HashMap::from([
+            (String::from("video-player"), String::from("mpv")),
+            (String::from("browser"), String::from("explorer")),
+            (
+                String::from("terminal-emulator"),
+                String::from("cmd /c start cmd /k"),
+            ),
+            (String::from("youtube-downloader"), String::from("yt-dlp")),
+            (
+                String::from("download-path"),
+                paths::default_download_path(),
+            ),
+            (
+                String::from("save-path"),
+                paths::default_save_path(),
+            ),
+        ])
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        HashMap::from([
+            (String::from("video-player"), String::from("mpv")),
+            (String::from("browser"), String::from("xdg-open")),
+            (
+                String::from("terminal-emulator"),
+                String::from("konsole -e"),
+            ),
+            (String::from("youtube-downloader"), String::from("yt-dlp")),
+            (
+                String::from("download-path"),
+                String::from("~/Downloads/%(title)s-%(id)s.%(ext)s"),
+            ),
+            (
+                String::from("save-path"),
+                String::from("~/.local/share/youtube-tui/saved/"),
+            ),
+        ])
+    }
 }
 
 fn shell_default() -> String {
-    String::from("sh")
+    #[cfg(target_os = "windows")]
+    {
+        String::from("cmd")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        String::from("sh")
+    }
 }
 
 fn api_key_default() -> String {

--- a/src/config/remap.rs
+++ b/src/config/remap.rs
@@ -6,11 +6,13 @@ use std::{
 };
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use home::home_dir;
 use serde::{Deserialize, Serialize};
 use typemap::Key;
 
-use crate::global::traits::{ConfigTrait, EXTENSION};
+use crate::global::{
+    functions::paths,
+    traits::{ConfigTrait, EXTENSION},
+};
 
 use super::{serde::KeyCodeSerde, WriteConfig};
 
@@ -86,8 +88,8 @@ impl RemapConfig {
             return Ok(keybindings);
         }
 
-        let config_path = home_dir().unwrap().join(format!(
-            ".config/youtube-tui/{}.{}",
+        let config_path = paths::config_dir().join(format!(
+            "{}.{}",
             RemapConfigSerde::LABEL,
             EXTENSION
         ));

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,10 +1,10 @@
-use home::home_dir;
 use std::{collections::HashSet, error::Error, fs};
 use tui_additions::framework::Framework;
 
 use crate::{
     config::MainConfig,
     global::{
+        functions::paths,
         structs::*,
         traits::{Collection, CollectionNoId},
     },
@@ -51,10 +51,9 @@ pub fn exit(framework: &mut Framework) -> Result<(), Box<dyn Error>> {
 
     let cached_before = CACHED_BEFORE.get().unwrap();
 
-    let info_path = home_dir().unwrap().join(".local/share/youtube-tui/info/");
-    let thumbnail_path = home_dir()
-        .unwrap()
-        .join(".local/share/youtube-tui/thumbnails/");
+    let data = paths::data_dir();
+    let info_path = data.join("info");
+    let thumbnail_path = data.join("thumbnails");
 
     // remove cache that no longer exists
     for deleted in cached_before

--- a/src/global/functions/download_all_images.rs
+++ b/src/global/functions/download_all_images.rs
@@ -46,9 +46,7 @@ pub fn download_all_images(downloads: Vec<Option<DownloadRequest>>) {
         return;
     }
 
-    let path = home::home_dir()
-        .expect("Cannot get your home directory")
-        .join(".local/share/youtube-tui/thumbnails/");
+    let path = super::paths::data_dir().join("thumbnails");
 
     downloads.into_iter().flatten().for_each(|req| {
         LocalStore::add_image(req.id.clone());

--- a/src/global/functions/find_library.rs
+++ b/src/global/functions/find_library.rs
@@ -1,16 +1,30 @@
 use std::{fs, path::PathBuf};
 
-use home::home_dir;
-
 use crate::config::MainConfig;
 
+use super::paths;
+
 pub fn find_library_item(id: &str, mainconfig: &MainConfig) -> Option<PathBuf> {
-    fs::read_dir(
-        home_dir()
+    let save_path_str = mainconfig.env.get("save-path")?;
+
+    // Resolve save-path: handle tilde expansion for backward compatibility
+    let save_path = if save_path_str.starts_with("~/") || save_path_str.starts_with("~\\") {
+        home::home_dir()
             .unwrap()
-            .join(mainconfig.env.get("save-path")?.replacen("~/", "", 1)),
-    )
-    .ok()?
-    .filter_map(|entry| Some(entry.ok()?.path()))
-    .find(|stem| stem.as_os_str().to_str().unwrap_or_default().contains(id))
+            .join(&save_path_str[2..])
+    } else {
+        // If it's an absolute path (e.g., from paths::default_save_path()), use directly
+        let p = PathBuf::from(save_path_str);
+        if p.is_absolute() {
+            p
+        } else {
+            // Relative path: treat as relative to data_dir for safety
+            paths::data_dir().join(save_path_str)
+        }
+    };
+
+    fs::read_dir(save_path)
+        .ok()?
+        .filter_map(|entry| Some(entry.ok()?.path()))
+        .find(|stem| stem.as_os_str().to_str().unwrap_or_default().contains(id))
 }

--- a/src/global/functions/init_move.rs
+++ b/src/global/functions/init_move.rs
@@ -1,11 +1,10 @@
 use std::fs;
 
-use home::home_dir;
+use super::paths;
 
 pub fn init_move() {
-    let home_dir = home_dir().unwrap();
-    let store_dir = home_dir.join(".local/share/youtube-tui/");
-    let cache_dir = home_dir.join(".cache/youtube-tui");
+    let store_dir = paths::data_dir();
+    let cache_dir = paths::cache_dir();
 
     let store_info_dir = store_dir.join("info/");
     let cache_info_dir = cache_dir.join("info/");

--- a/src/global/functions/mod.rs
+++ b/src/global/functions/mod.rs
@@ -35,3 +35,4 @@ mod key_input;
 pub use key_input::*;
 mod find_library;
 pub use find_library::*;
+pub mod paths;

--- a/src/global/functions/paths.rs
+++ b/src/global/functions/paths.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+/// Returns the configuration directory for youtube-tui.
+///
+/// - Linux: `~/.config/youtube-tui/`
+/// - Windows: `%APPDATA%\youtube-tui\`
+/// - macOS: `~/Library/Application Support/youtube-tui/`
+pub fn config_dir() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| home::home_dir().unwrap().join(".config"))
+        .join("youtube-tui")
+}
+
+/// Returns the data directory for youtube-tui.
+///
+/// - Linux: `~/.local/share/youtube-tui/`
+/// - Windows: `%LOCALAPPDATA%\youtube-tui\`
+/// - macOS: `~/Library/Application Support/youtube-tui/`
+pub fn data_dir() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| home::home_dir().unwrap().join(".local").join("share"))
+        .join("youtube-tui")
+}
+
+/// Returns the cache directory for youtube-tui.
+///
+/// - Linux: `~/.cache/youtube-tui/`
+/// - Windows: `%LOCALAPPDATA%\youtube-tui\cache\`
+/// - macOS: `~/Library/Caches/youtube-tui/`
+pub fn cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| home::home_dir().unwrap().join(".cache"))
+        .join("youtube-tui")
+}
+
+/// Returns the storage directory for rustypipe.
+///
+/// - Linux: `~/.local/share/rustypipe/`
+/// - Windows: `%LOCALAPPDATA%\rustypipe\`
+/// - macOS: `~/Library/Application Support/rustypipe/`
+pub fn rustypipe_dir() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| home::home_dir().unwrap().join(".local").join("share"))
+        .join("rustypipe")
+}
+
+/// Returns the default save path string for the `save-path` env variable.
+/// This is used in command strings, so it returns a String with trailing separator.
+pub fn default_save_path() -> String {
+    let p = data_dir().join("saved");
+    let mut s = p.to_string_lossy().to_string();
+    // Ensure trailing path separator for command substitution
+    if !s.ends_with(std::path::MAIN_SEPARATOR) {
+        s.push(std::path::MAIN_SEPARATOR);
+    }
+    s
+}
+
+/// Returns the default download path string for the `download-path` env variable.
+pub fn default_download_path() -> String {
+    let downloads = dirs::download_dir()
+        .unwrap_or_else(|| home::home_dir().unwrap().join("Downloads"));
+    let mut s = downloads.to_string_lossy().to_string();
+    if !s.ends_with(std::path::MAIN_SEPARATOR) {
+        s.push(std::path::MAIN_SEPARATOR);
+    }
+    format!("{s}%(title)s-%(id)s.%(ext)s")
+}

--- a/src/global/functions/run_command.rs
+++ b/src/global/functions/run_command.rs
@@ -4,7 +4,6 @@ use crate::{
     load_configs,
 };
 use crossterm::event::{KeyEvent, KeyModifiers};
-use home::home_dir;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::{
     env,
@@ -156,17 +155,14 @@ pub fn run_single_command(
         }
         ["rmcache", id] => {
             let res = LocalStore::rm_cache(id);
+            let data = paths::data_dir();
             let _ = fs::remove_file(
-                home_dir()
-                    .unwrap()
-                    .join(".local/share/youtube-tui/info/")
+                data.join("info")
                     .join(id)
                     .with_extension("json"),
             );
             let _ = fs::remove_file(
-                home_dir()
-                    .unwrap()
-                    .join(".local/share/youtube-tui/thumbnails/")
+                data.join("thumbnails")
                     .join(id),
             );
             if res {
@@ -351,9 +347,11 @@ pub fn run_single_command(
             let command = command[1..].join(" ");
             *framework.data.global.get_mut::<Message>().unwrap() =
                 Message::Success(command.clone());
+            let shell = &framework.data.global.get::<MainConfig>().unwrap().shell;
+            let shell_flag = shell_flag(shell);
             if let Ok(mut child) =
-                Command::new(&framework.data.global.get::<MainConfig>().unwrap().shell)
-                    .args(["-c", &command])
+                Command::new(shell)
+                    .args([shell_flag, &command])
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())
                     .spawn()
@@ -365,8 +363,10 @@ pub fn run_single_command(
             let command = command[1..].join(" ");
             *framework.data.global.get_mut::<Message>().unwrap() =
                 Message::Success(command.clone());
-            let _ = Command::new(&framework.data.global.get::<MainConfig>().unwrap().shell)
-                .args(["-c", &command])
+            let shell = &framework.data.global.get::<MainConfig>().unwrap().shell;
+            let shell_flag = shell_flag(shell);
+            let _ = Command::new(shell)
+                .args([shell_flag, &command])
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .spawn();
@@ -652,6 +652,30 @@ pub fn run_single_command(
             *framework.data.global.get_mut::<Message>().unwrap() =
                 Message::Error(format!("Unknown command: `{}`", command.join(" ")));
         }
+    }
+}
+
+/// Returns the appropriate shell flag for the given shell command.
+///
+/// On Windows, `cmd` and `cmd.exe` use `/C`, `powershell`/`pwsh` use `-Command`,
+/// and everything else (e.g., bash from Git for Windows) uses `-c`.
+/// On non-Windows platforms, always uses `-c`.
+fn shell_flag(shell: &str) -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        let shell_lower = shell.to_lowercase();
+        if shell_lower == "cmd" || shell_lower == "cmd.exe" {
+            "/C"
+        } else if shell_lower.contains("powershell") || shell_lower.contains("pwsh") {
+            "-Command"
+        } else {
+            "-c"
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = shell;
+        "-c"
     }
 }
 

--- a/src/global/structs/history.rs
+++ b/src/global/structs/history.rs
@@ -13,7 +13,7 @@ impl Key for WatchHistory {
 }
 
 impl Collection<Item> for WatchHistory {
-    const INDEX_PATH: &'static str = ".local/share/youtube-tui/watch_history.json";
+    const INDEX_PATH: &'static str = "watch_history.json";
 
     fn items(&self) -> &Vec<Item> {
         &self.0
@@ -36,7 +36,7 @@ impl Key for SearchHistory {
 }
 
 impl CollectionNoId<String> for SearchHistory {
-    const INDEX_PATH: &'static str = ".local/share/youtube-tui/search_history.json";
+    const INDEX_PATH: &'static str = "search_history.json";
 
     fn items(&self) -> &Vec<String> {
         &self.0
@@ -59,7 +59,7 @@ impl Key for CommandHistory {
 }
 
 impl CollectionNoId<String> for CommandHistory {
-    const INDEX_PATH: &'static str = ".local/share/youtube-tui/command_history.json";
+    const INDEX_PATH: &'static str = "command_history.json";
 
     fn items(&self) -> &Vec<String> {
         &self.0
@@ -83,7 +83,7 @@ impl Key for ChannelHistory {
 }
 
 impl CollectionNoId<String> for ChannelHistory {
-    const INDEX_PATH: &'static str = ".local/share/youtube-tui/channel_history.json";
+    const INDEX_PATH: &'static str = "channel_history.json";
 
     fn items(&self) -> &Vec<String> {
         &self.0

--- a/src/global/structs/library.rs
+++ b/src/global/structs/library.rs
@@ -12,7 +12,7 @@ impl Key for Library {
 }
 
 impl Collection<Item> for Library {
-    const INDEX_PATH: &'static str = ".local/share/youtube-tui/library.json";
+    const INDEX_PATH: &'static str = "library.json";
 
     fn items(&self) -> &Vec<Item> {
         &self.0

--- a/src/global/structs/localstore.rs
+++ b/src/global/structs/localstore.rs
@@ -6,13 +6,12 @@
 // this needs to change
 use std::{
     collections::{HashMap, HashSet},
-    env::home_dir,
     fs::{self, OpenOptions},
     io::Write,
     sync::OnceLock,
 };
 
-use crate::global::structs::Item;
+use crate::global::{functions::paths, structs::Item};
 
 static mut LOCALSTORE: OnceLock<LocalStore> = OnceLock::new();
 
@@ -48,10 +47,9 @@ impl LocalStore {
             .unwrap()
             .downloaded_images
             .remove(id);
-        let info_path = home_dir().unwrap().join(".local/share/youtube-tui/info/");
-        let thumbnail_path = home_dir()
-            .unwrap()
-            .join(".local/share/youtube-tui/thumbnails/");
+        let data = paths::data_dir();
+        let info_path = data.join("info");
+        let thumbnail_path = data.join("thumbnails");
         let _ = fs::remove_file(info_path.join(id).with_extension("json"));
         let _ = fs::remove_file(thumbnail_path.join(id));
 
@@ -64,9 +62,8 @@ impl LocalStore {
         match localstore.info.get(id) {
             Some(LocalRecord { item, .. }) => Some(item.clone()),
             None => {
-                let path = home_dir()
-                    .unwrap()
-                    .join(format!(".local/share/youtube-tui/info/{id}.json"));
+                let path = paths::data_dir()
+                    .join(format!("info/{id}.json"));
 
                 if path.exists() {
                     serde_json::from_str(&fs::read_to_string(path).ok()?).ok()?
@@ -83,7 +80,7 @@ impl LocalStore {
     }
 
     pub fn save_only(ids: &HashSet<String>) {
-        let info_path = home_dir().unwrap().join(".local/share/youtube-tui/info/");
+        let info_path = paths::data_dir().join("info");
 
         for (id, LocalRecord { item, is_new }) in unsafe { LOCALSTORE.get() }.unwrap().info.iter() {
             let info = info_path.join(id).with_extension("json");

--- a/src/global/structs/providers/rustypipe.rs
+++ b/src/global/structs/providers/rustypipe.rs
@@ -24,7 +24,7 @@ impl Default for RustyPipeWrapper {
     fn default() -> Self {
         Self(
             RustyPipe::builder()
-                .storage_dir(home::home_dir().unwrap().join(".local/share/rustypipe"))
+                .storage_dir(crate::global::functions::paths::rustypipe_dir())
                 .build()
                 .unwrap(),
         )

--- a/src/global/structs/subscriptions.rs
+++ b/src/global/structs/subscriptions.rs
@@ -7,7 +7,6 @@ use crate::{
     },
 };
 use chrono::Utc;
-use home::home_dir;
 use serde::*;
 use std::{
     error::Error,
@@ -247,9 +246,8 @@ fn update_channel_cache(
     channel: &FullChannelItem,
     image_index: usize,
 ) -> Result<(), Box<dyn Error>> {
-    let home_dir = home_dir().unwrap();
-    let cache_path = home_dir.join(format!(
-        ".local/share/youtube-tui/channels/{}.json",
+    let cache_path = crate::global::functions::paths::data_dir().join(format!(
+        "channels/{}.json",
         channel.id
     ));
 
@@ -318,7 +316,7 @@ impl CollectionItem for SubItem {
 }
 
 impl Collection<SubItem> for Subscriptions {
-    const INDEX_PATH: &'static str = ".local/share/youtube-tui/subscriptions.json";
+    const INDEX_PATH: &'static str = "subscriptions.json";
 
     fn items(&self) -> &Vec<SubItem> {
         &self.0
@@ -337,7 +335,7 @@ impl Collection<SubItem> for Subscriptions {
             .truncate(true)
             .write(true)
             .create(true)
-            .open(home_dir().unwrap().join(Self::INDEX_PATH))?;
+            .open(crate::global::functions::paths::data_dir().join(Self::INDEX_PATH))?;
 
         let save_string = serde_json::to_string_pretty(self)?;
         file.write_all(save_string.as_bytes())?;
@@ -349,7 +347,7 @@ impl Collection<SubItem> for Subscriptions {
     }
 
     fn load() -> Self {
-        let path = home_dir().unwrap().join(Self::INDEX_PATH);
+        let path = crate::global::functions::paths::data_dir().join(Self::INDEX_PATH);
         let res = (|| -> Result<Self, Box<dyn Error>> {
             let file_string = fs::read_to_string(&path)?;
             let deserialized = serde_json::from_str(&file_string)?;

--- a/src/global/traits/collection.rs
+++ b/src/global/traits/collection.rs
@@ -1,10 +1,11 @@
-use home::home_dir;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     error::Error,
     fs::{self, OpenOptions},
     io::Write,
 };
+
+use crate::global::functions::paths;
 
 pub trait CollectionItem {
     fn id(&self) -> Option<&str>;
@@ -40,7 +41,7 @@ where
                 .filter(|id| !id.is_empty())
                 .collect::<Vec<&str>>(),
         )?;
-        let path = home_dir().unwrap().join(Self::INDEX_PATH);
+        let path = paths::data_dir().join(Self::INDEX_PATH);
 
         let mut file = OpenOptions::new()
             .write(true)
@@ -88,7 +89,7 @@ where
 
     /// loads watch history from file
     fn load() -> Self {
-        let path = home_dir().unwrap().join(Self::INDEX_PATH);
+        let path = paths::data_dir().join(Self::INDEX_PATH);
         let res = (|| -> Result<Vec<String>, Box<dyn Error>> {
             let file_string = fs::read_to_string(&path)?;
             let deserialized = serde_json::from_str(&file_string)?;
@@ -98,7 +99,7 @@ where
         // if res is err, then the file either doesn't exist of has be altered incorrectly, in
         // which case returns Self::default()
         let items = if let Ok(deserialized) = res {
-            let info = home_dir().unwrap().join(".local/share/youtube-tui/info/");
+            let info = paths::data_dir().join("info");
             deserialized
                 .into_iter()
                 .filter_map(|id| fs::read_to_string(info.join(format!("{id}.json"))).ok())
@@ -124,11 +125,12 @@ where
 
     /// moves thumbnails of videos in watch history from cache back to storage when exiting, so that thumbnails can be viewed offline
     fn exit_move(&self) {
-        let home_dir = home_dir().unwrap();
-        let store_thumbnails_path = home_dir.join(".local/share/youtube-tui/thumbnails/");
-        let store_info_path = home_dir.join(".local/share/youtube-tui/info/");
-        let cache_thumbnails_path = home_dir.join(".cache/youtube-tui/thumbnails/");
-        let cache_info_path = home_dir.join(".cache/youtube-tui/info");
+        let data = paths::data_dir();
+        let cache = paths::cache_dir();
+        let store_thumbnails_path = data.join("thumbnails");
+        let store_info_path = data.join("info");
+        let cache_thumbnails_path = cache.join("thumbnails");
+        let cache_info_path = cache.join("info");
 
         self.items().iter().for_each(|item| {
             let id = item.id().unwrap_or("invalid-dump");
@@ -189,7 +191,7 @@ where
     /// saves the current state of watch history into a file
     fn save(&self) -> Result<(), Box<dyn Error>> {
         let save_string = serde_json::to_string_pretty(&self)?;
-        let path = home_dir().unwrap().join(Self::INDEX_PATH);
+        let path = paths::data_dir().join(Self::INDEX_PATH);
 
         let mut file = OpenOptions::new()
             .write(true)
@@ -218,7 +220,7 @@ where
 
     /// loads watch history from file
     fn load() -> Self {
-        let path = home_dir().unwrap().join(Self::INDEX_PATH);
+        let path = paths::data_dir().join(Self::INDEX_PATH);
         let res = (|| -> Result<Vec<T>, Box<dyn Error>> {
             let file_string = fs::read_to_string(&path)?;
             let deserialized = serde_json::from_str(&file_string)?;

--- a/src/global/traits/configtrait.rs
+++ b/src/global/traits/configtrait.rs
@@ -1,4 +1,3 @@
-use home::home_dir;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     error::Error,
@@ -6,7 +5,7 @@ use std::{
     io::Write,
 };
 
-use crate::config::WriteConfig;
+use crate::{config::WriteConfig, global::functions::paths};
 
 pub const EXTENSION: &str = "yml";
 
@@ -18,9 +17,8 @@ pub trait ConfigTrait {
     where
         Self: Serialize + DeserializeOwned + Default + Clone,
     {
-        let home_dir = home_dir().unwrap();
         let config_path =
-            home_dir.join(format!(".config/youtube-tui/{}.{}", Self::LABEL, EXTENSION));
+            paths::config_dir().join(format!("{}.{}", Self::LABEL, EXTENSION));
 
         // The config struct
         let config: Self = {

--- a/src/init.rs
+++ b/src/init.rs
@@ -2,7 +2,6 @@ use crate::{
     config::*,
     global::{functions::*, structs::*, traits::*},
 };
-use home::home_dir;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::{
     collections::HashSet,
@@ -29,23 +28,19 @@ pub fn init(
     command: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
     LocalStore::init();
-    let home_dir = home_dir().unwrap();
     RUNTIME
         .set(Builder::new_current_thread().enable_all().build().unwrap())
         .unwrap();
 
     // creating files
+    let data = paths::data_dir();
     [
-        // ".cache/youtube-tui/thumbnails/",
-        // ".cache/youtube-tui/info/",
-        // ".cache/youtube-tui/channels/",
-        ".local/share/youtube-tui/thumbnails/",
-        ".local/share/youtube-tui/info/",
-        ".local/share/youtube-tui/saved/",
+        data.join("thumbnails"),
+        data.join("info"),
+        data.join("saved"),
     ]
     .into_iter()
-    .for_each(|s| {
-        let dir = home_dir.join(s);
+    .for_each(|dir| {
         if !dir.exists() {
             fs::create_dir_all(dir).unwrap();
         }
@@ -136,8 +131,7 @@ pub fn init(
 
 /// reload all config files
 pub fn load_configs(framework: &mut FrameworkClean) -> Result<(), Box<dyn Error>> {
-    let home_dir = home_dir().unwrap();
-    let config_path = home_dir.join(".config/youtube-tui/");
+    let config_path = paths::config_dir();
 
     if !&config_path.exists() {
         fs::create_dir_all(&config_path).unwrap();

--- a/src/items/iteminfo.rs
+++ b/src/items/iteminfo.rs
@@ -53,9 +53,8 @@ impl FrameworkItem for ItemInfo {
 
             #[cfg(any(feature = "sixel", feature = "halfblock"))]
             {
-                let thumbnail_path = home::home_dir()
-                    .unwrap()
-                    .join(".local/share/youtube-tui/thumbnails/")
+                let thumbnail_path = crate::global::functions::paths::data_dir()
+                    .join("thumbnails")
                     .join(item.thumbnail_id());
                 if thumbnail_path.exists() {
                     #[cfg(any(feature = "sixel", feature = "halfblock"))]

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, Event, MouseButton, MouseEventKind};
+use crossterm::event::{self, Event, KeyEventKind, MouseButton, MouseEventKind};
 use ratatui::{backend::CrosstermBackend, Terminal};
 #[cfg(feature = "mpv")]
 use std::time::{Duration, Instant};
@@ -272,7 +272,11 @@ pub fn run(
                         .push(Task::RenderAll);
                 }
             }
-            Event::Key(key) => key_input(key, framework, terminal),
+            // Only handle Press events; ignore Release/Repeat to avoid
+            // duplicate key actions on Windows terminals that send enhanced key events.
+            Event::Key(key) if key.kind == KeyEventKind::Press => {
+                key_input(key, framework, terminal)
+            }
             // always render if there is a screen resize event
             Event::Resize(_, _) => {
                 framework


### PR DESCRIPTION
Replace Unix-specific path assumptions and shell commands with platform-aware alternatives using the \dirs\ crate. Introduce a \paths\ module for canonical config/data/cache directories, swap hardcoded single-quote delimiters for runtime-selected quote chars, use \cmd /C\ and Windows file-deletion commands where appropriate, and filter duplicate key events (Press-only) to fix double-input on Windows terminals.