### PR TITLE
fix/windows mpv build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,23 +2,29 @@ fn main() {
     // On Windows, help the linker find mpv.lib when building with the mpv feature.
     //
     // Priority:
-    //   1. MPV_LIB_DIR env var              — CI / custom installs
+    //   1. MPV_LIB_DIR env var                — CI / custom installs
     //   2. %LOCALAPPDATA%\youtube-tui\mpv-dev — persistent user location (survives cargo install)
-    //   3. <manifest>/mpv-dev               — local project checkout
-    //   4. Run setup-mpv-dev.ps1            — download and generate mpv.lib on first build
+    //   3. <manifest>/mpv-dev                 — local project checkout
+    //   4. Run setup-mpv-dev.ps1              — download and generate mpv.lib on first build
+    //
+    // After locating mpv.lib, libmpv-2.dll is copied to both:
+    //   - %CARGO_HOME%\bin\  (where cargo install places the exe)
+    //   - target\release\    (where cargo build places the exe)
     #[cfg(all(target_os = "windows", feature = "mpv"))]
     {
         println!("cargo:rerun-if-env-changed=MPV_LIB_DIR");
         println!("cargo:rerun-if-env-changed=LOCALAPPDATA");
+        println!("cargo:rerun-if-env-changed=CARGO_HOME");
 
         // 1. Explicit env var override (CI / custom installs)
         if let Ok(dir) = std::env::var("MPV_LIB_DIR") {
-            println!("cargo:rustc-link-search=native={}", dir);
+            let dir = std::path::PathBuf::from(dir);
+            println!("cargo:rustc-link-search=native={}", dir.display());
+            copy_dll(&dir);
             return;
         }
 
-        // Persistent user-level location — works for both `cargo build` and `cargo install`.
-        // %LOCALAPPDATA%\youtube-tui\mpv-dev is always writable and survives across installs.
+        // Persistent user-level location — always writable, survives across `cargo install` runs.
         let persistent_dir = std::env::var("LOCALAPPDATA")
             .map(|d| {
                 std::path::PathBuf::from(d)
@@ -37,12 +43,12 @@ fn main() {
             println!("cargo:rerun-if-changed={}", lib.display());
             if lib.exists() {
                 println!("cargo:rustc-link-search=native={}", candidate.display());
+                copy_dll(candidate);
                 return;
             }
         }
 
         // 4. Neither location has mpv.lib — run setup-mpv-dev.ps1 to download it.
-        //    Output goes to the persistent user location so subsequent installs are instant.
         let script = std::path::Path::new(&manifest_dir).join("setup-mpv-dev.ps1");
         if !script.exists() {
             panic!(
@@ -93,5 +99,44 @@ fn main() {
         }
 
         println!("cargo:rustc-link-search=native={}", output_dir.display());
+        copy_dll(&output_dir);
+    }
+}
+
+/// Copy libmpv-2.dll next to the final binary so it can be found at runtime.
+///
+/// Two destinations are tried:
+///   1. %CARGO_HOME%\bin\  — where `cargo install` places the exe
+///   2. The `target/<profile>/` directory — where `cargo build` places the exe,
+///      derived by walking up from OUT_DIR
+#[cfg(all(target_os = "windows", feature = "mpv"))]
+fn copy_dll(mpv_dir: &std::path::Path) {
+    let dll = mpv_dir.join("libmpv-2.dll");
+    if !dll.exists() {
+        // DLL not present in the mpv-dev dir — nothing to copy.
+        return;
+    }
+
+    // 1. cargo install destination: %CARGO_HOME%\bin\
+    if let Ok(cargo_home) = std::env::var("CARGO_HOME") {
+        let dest = std::path::Path::new(&cargo_home)
+            .join("bin")
+            .join("libmpv-2.dll");
+        let _ = std::fs::copy(&dll, &dest);
+    }
+
+    // 2. cargo build destination: OUT_DIR is something like
+    //    <root>/target/<profile>/build/<crate>/out
+    //    Walking up 3 levels reaches <root>/target/<profile>/
+    if let Ok(out_dir) = std::env::var("OUT_DIR") {
+        let target_profile = std::path::Path::new(&out_dir)
+            .parent() // out
+            .and_then(|p| p.parent()) // <crate>
+            .and_then(|p| p.parent()) // build
+            .and_then(|p| p.parent()); // <profile> (e.g. release / debug)
+        if let Some(dir) = target_profile {
+            let dest = dir.join("libmpv-2.dll");
+            let _ = std::fs::copy(&dll, dest);
+        }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,29 +1,48 @@
 fn main() {
     // On Windows, help the linker find mpv.lib when building with the mpv feature.
-    // Priority: MPV_LIB_DIR env var → local mpv-dev/ dir → run setup-mpv-dev.ps1 to create it.
+    //
+    // Priority:
+    //   1. MPV_LIB_DIR env var              — CI / custom installs
+    //   2. %LOCALAPPDATA%\youtube-tui\mpv-dev — persistent user location (survives cargo install)
+    //   3. <manifest>/mpv-dev               — local project checkout
+    //   4. Run setup-mpv-dev.ps1            — download and generate mpv.lib on first build
     #[cfg(all(target_os = "windows", feature = "mpv"))]
     {
-        // Tell Cargo to re-run this script only when these change, not on every build.
-        println!("cargo:rerun-if-changed=mpv-dev/mpv.lib");
         println!("cargo:rerun-if-env-changed=MPV_LIB_DIR");
+        println!("cargo:rerun-if-env-changed=LOCALAPPDATA");
 
-        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-        let local_mpv = std::path::Path::new(&manifest_dir).join("mpv-dev");
-        let mpv_lib = local_mpv.join("mpv.lib");
-
-        // 1. Explicit env var override (CI / custom setups)
+        // 1. Explicit env var override (CI / custom installs)
         if let Ok(dir) = std::env::var("MPV_LIB_DIR") {
             println!("cargo:rustc-link-search=native={}", dir);
             return;
         }
 
-        // 2. mpv.lib already exists locally from a previous run — fast path
-        if mpv_lib.exists() {
-            println!("cargo:rustc-link-search=native={}", local_mpv.display());
-            return;
+        // Persistent user-level location — works for both `cargo build` and `cargo install`.
+        // %LOCALAPPDATA%\youtube-tui\mpv-dev is always writable and survives across installs.
+        let persistent_dir = std::env::var("LOCALAPPDATA")
+            .map(|d| {
+                std::path::PathBuf::from(d)
+                    .join("youtube-tui")
+                    .join("mpv-dev")
+            })
+            .ok();
+
+        // Local project-relative fallback (convenient for development checkouts)
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let local_dir = std::path::Path::new(&manifest_dir).join("mpv-dev");
+
+        // 2 & 3. Check both locations for an existing mpv.lib — fast path
+        for candidate in persistent_dir.iter().chain(std::iter::once(&local_dir)) {
+            let lib = candidate.join("mpv.lib");
+            println!("cargo:rerun-if-changed={}", lib.display());
+            if lib.exists() {
+                println!("cargo:rustc-link-search=native={}", candidate.display());
+                return;
+            }
         }
 
-        // 3. Run setup-mpv-dev.ps1 to download and generate mpv.lib automatically
+        // 4. Neither location has mpv.lib — run setup-mpv-dev.ps1 to download it.
+        //    Output goes to the persistent user location so subsequent installs are instant.
         let script = std::path::Path::new(&manifest_dir).join("setup-mpv-dev.ps1");
         if !script.exists() {
             panic!(
@@ -34,8 +53,11 @@ fn main() {
             );
         }
 
+        // Prefer the persistent directory; fall back to the local project dir.
+        let output_dir = persistent_dir.unwrap_or(local_dir.clone());
+
         eprintln!(
-            "cargo:warning=mpv.lib not found — running setup-mpv-dev.ps1 to download it (~30MB)..."
+            "cargo:warning=mpv.lib not found — running setup-mpv-dev.ps1 (~30MB download)..."
         );
 
         let status = std::process::Command::new("powershell")
@@ -44,6 +66,8 @@ fn main() {
                 "Bypass",
                 "-File",
                 &script.to_string_lossy(),
+                "-OutputDir",
+                &output_dir.to_string_lossy(),
             ])
             .status()
             .expect("Failed to launch PowerShell to run setup-mpv-dev.ps1");
@@ -58,6 +82,7 @@ fn main() {
             );
         }
 
+        let mpv_lib = output_dir.join("mpv.lib");
         if !mpv_lib.exists() {
             panic!(
                 "\n\nERROR: setup-mpv-dev.ps1 completed but mpv.lib was not found at:\n  {}\n\
@@ -67,6 +92,6 @@ fn main() {
             );
         }
 
-        println!("cargo:rustc-link-search=native={}", local_mpv.display());
+        println!("cargo:rustc-link-search=native={}", output_dir.display());
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,20 +1,72 @@
 fn main() {
     // On Windows, help the linker find mpv.lib when building with the mpv feature.
-    // Check MPV_LIB_DIR env var, then fall back to a local mpv-dev directory.
+    // Priority: MPV_LIB_DIR env var → local mpv-dev/ dir → run setup-mpv-dev.ps1 to create it.
     #[cfg(all(target_os = "windows", feature = "mpv"))]
     {
+        // Tell Cargo to re-run this script only when these change, not on every build.
+        println!("cargo:rerun-if-changed=mpv-dev/mpv.lib");
+        println!("cargo:rerun-if-env-changed=MPV_LIB_DIR");
+
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let local_mpv = std::path::Path::new(&manifest_dir).join("mpv-dev");
+        let mpv_lib = local_mpv.join("mpv.lib");
+
+        // 1. Explicit env var override (CI / custom setups)
         if let Ok(dir) = std::env::var("MPV_LIB_DIR") {
             println!("cargo:rustc-link-search=native={}", dir);
-        } else {
-            // Check for a local mpv-dev directory (created by setup-mpv-dev.ps1)
-            let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-            let local_mpv = std::path::Path::new(&manifest_dir).join("mpv-dev");
-            if local_mpv.exists() {
-                println!(
-                    "cargo:rustc-link-search=native={}",
-                    local_mpv.display()
-                );
-            }
+            return;
         }
+
+        // 2. mpv.lib already exists locally from a previous run — fast path
+        if mpv_lib.exists() {
+            println!("cargo:rustc-link-search=native={}", local_mpv.display());
+            return;
+        }
+
+        // 3. Run setup-mpv-dev.ps1 to download and generate mpv.lib automatically
+        let script = std::path::Path::new(&manifest_dir).join("setup-mpv-dev.ps1");
+        if !script.exists() {
+            panic!(
+                "\n\nERROR: mpv.lib not found and setup-mpv-dev.ps1 is missing.\n\
+                 Run the setup script manually:\n\
+                 \n  .\\setup-mpv-dev.ps1\n\n\
+                 Or set MPV_LIB_DIR to a directory containing mpv.lib.\n"
+            );
+        }
+
+        eprintln!(
+            "cargo:warning=mpv.lib not found — running setup-mpv-dev.ps1 to download it (~30MB)..."
+        );
+
+        let status = std::process::Command::new("powershell")
+            .args([
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                &script.to_string_lossy(),
+            ])
+            .status()
+            .expect("Failed to launch PowerShell to run setup-mpv-dev.ps1");
+
+        if !status.success() {
+            panic!(
+                "\n\nERROR: setup-mpv-dev.ps1 failed (exit code: {:?}).\n\
+                 Run it manually to see the full error:\n\
+                 \n  .\\setup-mpv-dev.ps1\n\n\
+                 Or set MPV_LIB_DIR to a directory containing mpv.lib.\n",
+                status.code()
+            );
+        }
+
+        if !mpv_lib.exists() {
+            panic!(
+                "\n\nERROR: setup-mpv-dev.ps1 completed but mpv.lib was not found at:\n  {}\n\
+                 Run the script manually to diagnose:\n\
+                 \n  .\\setup-mpv-dev.ps1\n",
+                mpv_lib.display()
+            );
+        }
+
+        println!("cargo:rustc-link-search=native={}", local_mpv.display());
     }
 }

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -68,15 +68,20 @@ If installed correctly, a TUI should be launched. Press `q` to close the TUI.
 
 ## Installation on Windows
 
-Install using `cargo`:
+Install using `cargo` exactly as you would on Linux:
 
 ```sh
 cargo install youtube-tui
 ```
 
-All default features work on Windows. The `sixel` feature uses a pure Rust encoder on Windows (no native dependencies). The `clipboard` feature uses native Windows clipboard APIs.
+All default features work on Windows. On the first build, the `mpv` feature will automatically download the required `libmpv` dev library (~30MB) and place `libmpv-2.dll` next to the installed binary — no manual steps needed.
 
-If you do not have `mpv` installed, you can disable the `mpv` feature:
+Prerequisites:
+- [Rust / cargo](https://www.rust-lang.org/tools/install)
+- [MSVC build tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022) ("Desktop development with C++" workload) — required to compile Rust on Windows
+- Internet access on the first build (to download `libmpv`)
+
+To build without the embedded mpv audio player (skips the download):
 
 ```sh
 cargo install youtube-tui --no-default-features -F sixel -F halfblock -F clipboard -F rustypipe
@@ -121,9 +126,11 @@ On Linux, requires <a href="https://xcb.freedesktop.org/" target=_blank>`libxcb`
 
 ### `mpv` (default)
 
-Embedded audio player
+Embedded audio player.
 
-Requires <a href="https://mpv.io/" target=_blank>`mpv`</a> (libmpv) to be installed in your system. On Windows, `mpv.dll` must be available in your PATH or next to the executable.
+On Linux, requires <a href="https://mpv.io/" target=_blank>`libmpv`</a> to be installed (`libmpv-dev` on Debian/Ubuntu, `mpv` on Arch).
+
+On Windows, the build system downloads `libmpv` automatically on first build and copies `libmpv-2.dll` next to the installed binary. No manual steps are required.
 
 ### rustypipe (default)
 

--- a/setup-mpv-dev.ps1
+++ b/setup-mpv-dev.ps1
@@ -1,17 +1,31 @@
 # Downloads mpv dev library for Windows (required to build with the `mpv` feature)
-# Usage: .\setup-mpv-dev.ps1
-# This downloads ~30MB and extracts mpv.lib + libmpv-2.dll into a local 'mpv-dev' folder.
-# Then sets MPV_LIB_DIR for the current session.
+#
+# Usage:
+#   .\setup-mpv-dev.ps1                          # outputs to .\mpv-dev\
+#   .\setup-mpv-dev.ps1 -OutputDir "C:\some\dir" # outputs to a custom directory
+#
+# When called from build.rs, -OutputDir is set to %LOCALAPPDATA%\youtube-tui\mpv-dev
+# so the files persist across `cargo install` invocations.
+
+param(
+    [string]$OutputDir = ""
+)
 
 $ErrorActionPreference = "Stop"
 
-$mpvDevDir = Join-Path $PSScriptRoot "mpv-dev"
-$mpvLib = Join-Path $mpvDevDir "mpv.lib"
+# Determine output directory:
+#   - Explicit -OutputDir argument (used by build.rs)
+#   - Otherwise default to a sibling mpv-dev\ next to this script
+if ($OutputDir -eq "") {
+    $OutputDir = Join-Path $PSScriptRoot "mpv-dev"
+}
+
+$mpvLib = Join-Path $OutputDir "mpv.lib"
 
 if (Test-Path $mpvLib) {
-    Write-Host "mpv.lib already exists at $mpvDevDir, skipping download."
-    $env:MPV_LIB_DIR = $mpvDevDir
-    Write-Host "MPV_LIB_DIR set to $mpvDevDir"
+    Write-Host "mpv.lib already exists at $OutputDir, skipping download."
+    $env:MPV_LIB_DIR = $OutputDir
+    Write-Host "MPV_LIB_DIR set to $OutputDir"
     return
 }
 
@@ -19,14 +33,18 @@ if (Test-Path $mpvLib) {
 $arch = if ([Environment]::Is64BitOperatingSystem) { "x86_64" } else { "i686" }
 $url = "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260412/mpv-dev-${arch}-20260412-git-062f4bf.7z"
 
+# Use the user-local temp directory (always writable, unlike C:\Windows\Temp)
+$userTemp = [System.IO.Path]::GetTempPath()
+$tempFile = Join-Path $userTemp "mpv-dev.7z"
+$tempExtract = Join-Path $userTemp "mpv-dev-extract"
+
 Write-Host "Downloading mpv-dev for $arch..."
-$tempFile = Join-Path $env:TEMP "mpv-dev.7z"
 Invoke-WebRequest -Uri $url -OutFile $tempFile -UserAgent "Mozilla/5.0"
 
 # Create output directory
-New-Item -ItemType Directory -Force -Path $mpvDevDir | Out-Null
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 
-# Extract using 7z (ships with scoop, git, or can be installed via scoop install 7zip)
+# Locate 7z — check PATH first, then common install locations
 $7zPaths = @(
     "7z",
     "$env:ProgramFiles\7-Zip\7z.exe",
@@ -53,7 +71,6 @@ if (-not $7zExe) {
 }
 
 Write-Host "Extracting mpv-dev..."
-$tempExtract = Join-Path $env:TEMP "mpv-dev-extract"
 if (Test-Path $tempExtract) { Remove-Item -Recurse -Force $tempExtract }
 & $7zExe x $tempFile -o"$tempExtract" -y | Out-Null
 
@@ -63,7 +80,7 @@ $dllFile = Get-ChildItem -Path $tempExtract -Filter "libmpv-2.dll" -Recurse | Se
 
 if (-not $libFile) {
     # The shinchiro builds ship libmpv.dll.a (GCC format), not mpv.lib (MSVC format).
-    # Generate mpv.lib from the DLL using dumpbin + lib (MSVC tools).
+    # Generate mpv.lib from the DLL using MSVC dumpbin + lib tools.
     Write-Host "mpv.lib not found in archive. Generating from libmpv-2.dll..."
 
     $dllForLib = Get-ChildItem -Path $tempExtract -Filter "libmpv-2.dll" -Recurse | Select-Object -First 1
@@ -71,7 +88,7 @@ if (-not $libFile) {
         Write-Error "Could not find libmpv-2.dll in the archive!"
     }
 
-    # Find MSVC tools (dumpbin, lib) - they're installed but not in PATH
+    # Find MSVC tools — installed but not in PATH by default
     $vsBase = "${env:ProgramFiles(x86)}\Microsoft Visual Studio"
     if (-not (Test-Path $vsBase)) { $vsBase = "$env:ProgramFiles\Microsoft Visual Studio" }
     $dumpbin = Get-ChildItem -Path $vsBase -Recurse -Filter "dumpbin.exe" -ErrorAction SilentlyContinue |
@@ -85,55 +102,46 @@ if (-not $libFile) {
         Write-Error "Could not find MSVC build tools (dumpbin.exe, lib.exe). Install 'Desktop development with C++' workload."
     }
 
-    # Export function names from DLL
-    $defPath = Join-Path $mpvDevDir "mpv.def"
+    # Export function names from DLL and write .def file
+    $defPath = Join-Path $OutputDir "mpv.def"
     $exports = & $dumpbin /exports "$($dllForLib.FullName)" 2>&1 |
         Select-String "^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\S+)" |
         ForEach-Object { $_.Matches[0].Groups[1].Value }
 
-    # Write .def file
     $defContent = "LIBRARY libmpv-2`nEXPORTS`n"
     $defContent += ($exports | ForEach-Object { "    $_" }) -join "`n"
     Set-Content -Path $defPath -Value $defContent -Encoding ASCII
 
     # Generate .lib from .def
     $machine = if ($arch -eq "x86_64") { "x64" } else { "x86" }
-    & $libExe /def:"$defPath" /machine:$machine /out:"$mpvDevDir\mpv.lib" 2>&1 | Out-Null
+    & $libExe /def:"$defPath" /machine:$machine /out:"$OutputDir\mpv.lib" 2>&1 | Out-Null
 
-    if (-not (Test-Path "$mpvDevDir\mpv.lib")) {
+    if (-not (Test-Path "$OutputDir\mpv.lib")) {
         Write-Error "Failed to generate mpv.lib!"
     } else {
         Write-Host "Generated mpv.lib successfully."
     }
 } else {
-    Copy-Item $libFile.FullName $mpvDevDir
+    Copy-Item $libFile.FullName $OutputDir
 }
 
 if ($dllFile) {
-    Copy-Item $dllFile.FullName $mpvDevDir
-    # Also copy DLL next to the built binary location
-    $targetRelease = Join-Path $PSScriptRoot "target\release"
-    if (Test-Path $targetRelease) {
-        Copy-Item $dllFile.FullName $targetRelease
-    }
+    Copy-Item $dllFile.FullName $OutputDir
 }
 
-# Also grab any other DLLs we might need
+# Also grab any other DLLs from the archive
 Get-ChildItem -Path $tempExtract -Filter "*.dll" -Recurse | ForEach-Object {
-    Copy-Item $_.FullName $mpvDevDir -Force
+    Copy-Item $_.FullName $OutputDir -Force
 }
 
-# Cleanup
+# Cleanup temp files
 Remove-Item -Force $tempFile -ErrorAction SilentlyContinue
 Remove-Item -Recurse -Force $tempExtract -ErrorAction SilentlyContinue
 
-$env:MPV_LIB_DIR = $mpvDevDir
+$env:MPV_LIB_DIR = $OutputDir
 Write-Host ""
-Write-Host "Done! mpv dev files extracted to: $mpvDevDir"
-Write-Host "MPV_LIB_DIR set to: $mpvDevDir"
+Write-Host "Done! mpv dev files extracted to: $OutputDir"
+Write-Host "MPV_LIB_DIR set to: $OutputDir"
 Write-Host ""
-Write-Host "You can now build with:"
-Write-Host "  cargo build --release"
-Write-Host ""
-Write-Host "To make this permanent, add to your PowerShell profile:"
-Write-Host "  `$env:MPV_LIB_DIR = '$mpvDevDir'"
+Write-Host "To make MPV_LIB_DIR permanent, add to your PowerShell profile:"
+Write-Host "  `$env:MPV_LIB_DIR = '$OutputDir'"


### PR DESCRIPTION
- **build(windows): auto-download mpv dev library via build.rs**
- **build(windows): fix mpv setup for cargo install and restricted environments**
- **build(windows): auto-copy libmpv-2.dll next to the binary at build time**
- **docs(windows): update installation guide to reflect automatic mpv setup**
