### PR TITLE
feat(paths): respect XDG_CONFIG_HOME, XDG_DATA_HOME, XDG_CACHE_HOME on all platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,15 +1125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4226,7 +4217,6 @@ dependencies = [
  "dirs",
  "dyn-clone",
  "futures",
- "home",
  "http_req 0.14.4",
  "invidious",
  "libmpv-sirno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ rustypipe = []
 serde = {version = "1.0", default-features = false, features = ["derive"]}
 crossterm = {version = "0.29", default-features = false, features = ["serde"]}
 viuer = {version = "0.11", default-features = false, optional = true, features = ["print-file"]}
-home = "0.5"
 dirs = "5"
 chrono = {version = "0.4", default-features = false, features = ["clock"]}
 typemap = {version = "0.3", default-features = false}

--- a/src/config/main.rs
+++ b/src/config/main.rs
@@ -287,10 +287,9 @@ const fn write_to_config_default() -> WriteConfig {
 }
 
 fn default_env() -> HashMap<String, String> {
-    use crate::global::functions::paths;
-
     #[cfg(target_os = "windows")]
     {
+        use crate::global::functions::paths;
         HashMap::from([
             (String::from("video-player"), String::from("mpv")),
             (String::from("browser"), String::from("explorer")),

--- a/src/global/functions/find_library.rs
+++ b/src/global/functions/find_library.rs
@@ -9,7 +9,7 @@ pub fn find_library_item(id: &str, mainconfig: &MainConfig) -> Option<PathBuf> {
 
     // Resolve save-path: handle tilde expansion for backward compatibility
     let save_path = if save_path_str.starts_with("~/") || save_path_str.starts_with("~\\") {
-        home::home_dir()
+        dirs::home_dir()
             .unwrap()
             .join(&save_path_str[2..])
     } else {

--- a/src/global/functions/paths.rs
+++ b/src/global/functions/paths.rs
@@ -1,55 +1,78 @@
 use std::path::PathBuf;
 
+/// Returns the base config directory, respecting XDG_CONFIG_HOME on all platforms.
+///
+/// On Linux this is handled by `dirs` already. On Windows and macOS, `dirs`
+/// ignores XDG env vars, so we check manually first. This lets Windows users
+/// keep their config in `~/.config` by setting `XDG_CONFIG_HOME`.
+fn xdg_config_base() -> PathBuf {
+    std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::config_dir().unwrap_or_else(|| home::home_dir().unwrap().join(".config"))
+        })
+}
+
+/// Returns the base data directory, respecting XDG_DATA_HOME on all platforms.
+fn xdg_data_base() -> PathBuf {
+    std::env::var("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::data_local_dir()
+                .unwrap_or_else(|| home::home_dir().unwrap().join(".local").join("share"))
+        })
+}
+
+/// Returns the base cache directory, respecting XDG_CACHE_HOME on all platforms.
+fn xdg_cache_base() -> PathBuf {
+    std::env::var("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::cache_dir().unwrap_or_else(|| home::home_dir().unwrap().join(".cache"))
+        })
+}
+
 /// Returns the configuration directory for youtube-tui.
 ///
-/// - Linux: `~/.config/youtube-tui/`
-/// - Windows: `%APPDATA%\youtube-tui\`
-/// - macOS: `~/Library/Application Support/youtube-tui/`
+/// Respects `XDG_CONFIG_HOME` on all platforms. Platform defaults:
+/// - Linux:   `~/.config/youtube-tui/`
+/// - Windows: `%APPDATA%\youtube-tui\`   (or `~/.config/youtube-tui/` if XDG_CONFIG_HOME is set)
+/// - macOS:   `~/Library/Application Support/youtube-tui/`
 pub fn config_dir() -> PathBuf {
-    dirs::config_dir()
-        .unwrap_or_else(|| home::home_dir().unwrap().join(".config"))
-        .join("youtube-tui")
+    xdg_config_base().join("youtube-tui")
 }
 
 /// Returns the data directory for youtube-tui.
 ///
-/// - Linux: `~/.local/share/youtube-tui/`
+/// Respects `XDG_DATA_HOME` on all platforms. Platform defaults:
+/// - Linux:   `~/.local/share/youtube-tui/`
 /// - Windows: `%LOCALAPPDATA%\youtube-tui\`
-/// - macOS: `~/Library/Application Support/youtube-tui/`
+/// - macOS:   `~/Library/Application Support/youtube-tui/`
 pub fn data_dir() -> PathBuf {
-    dirs::data_local_dir()
-        .unwrap_or_else(|| home::home_dir().unwrap().join(".local").join("share"))
-        .join("youtube-tui")
+    xdg_data_base().join("youtube-tui")
 }
 
 /// Returns the cache directory for youtube-tui.
 ///
-/// - Linux: `~/.cache/youtube-tui/`
+/// Respects `XDG_CACHE_HOME` on all platforms. Platform defaults:
+/// - Linux:   `~/.cache/youtube-tui/`
 /// - Windows: `%LOCALAPPDATA%\youtube-tui\cache\`
-/// - macOS: `~/Library/Caches/youtube-tui/`
+/// - macOS:   `~/Library/Caches/youtube-tui/`
 pub fn cache_dir() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| home::home_dir().unwrap().join(".cache"))
-        .join("youtube-tui")
+    xdg_cache_base().join("youtube-tui")
 }
 
 /// Returns the storage directory for rustypipe.
 ///
-/// - Linux: `~/.local/share/rustypipe/`
-/// - Windows: `%LOCALAPPDATA%\rustypipe\`
-/// - macOS: `~/Library/Application Support/rustypipe/`
+/// Respects `XDG_DATA_HOME` on all platforms.
 pub fn rustypipe_dir() -> PathBuf {
-    dirs::data_local_dir()
-        .unwrap_or_else(|| home::home_dir().unwrap().join(".local").join("share"))
-        .join("rustypipe")
+    xdg_data_base().join("rustypipe")
 }
 
 /// Returns the default save path string for the `save-path` env variable.
-/// This is used in command strings, so it returns a String with trailing separator.
 pub fn default_save_path() -> String {
     let p = data_dir().join("saved");
     let mut s = p.to_string_lossy().to_string();
-    // Ensure trailing path separator for command substitution
     if !s.ends_with(std::path::MAIN_SEPARATOR) {
         s.push(std::path::MAIN_SEPARATOR);
     }
@@ -58,8 +81,8 @@ pub fn default_save_path() -> String {
 
 /// Returns the default download path string for the `download-path` env variable.
 pub fn default_download_path() -> String {
-    let downloads = dirs::download_dir()
-        .unwrap_or_else(|| home::home_dir().unwrap().join("Downloads"));
+    let downloads =
+        dirs::download_dir().unwrap_or_else(|| home::home_dir().unwrap().join("Downloads"));
     let mut s = downloads.to_string_lossy().to_string();
     if !s.ends_with(std::path::MAIN_SEPARATOR) {
         s.push(std::path::MAIN_SEPARATOR);

--- a/src/global/functions/paths.rs
+++ b/src/global/functions/paths.rs
@@ -1,85 +1,72 @@
 use std::path::PathBuf;
 
-/// Returns the base config directory, respecting XDG_CONFIG_HOME on all platforms.
+/// Returns the configuration directory for youtube-tui.
 ///
-/// On Linux this is handled by `dirs` already. On Windows and macOS, `dirs`
-/// ignores XDG env vars, so we check manually first. This lets Windows users
-/// keep their config in `~/.config` by setting `XDG_CONFIG_HOME`.
-fn sys_config_base() -> PathBuf {
+/// If `YOUTUBETUI_CONFIG_HOME` is set, it is used directly as the config directory.
+/// Otherwise falls back to the platform default with a `youtube-tui` subdirectory:
+/// - Linux:   `~/.config/youtube-tui/`
+/// - Windows: `%APPDATA%\youtube-tui\`
+/// - macOS:   `~/Library/Application Support/youtube-tui/`
+pub fn config_dir() -> PathBuf {
     std::env::var("YOUTUBETUI_CONFIG_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
             dirs::config_dir()
-                .expect("no config dir, set the YOUTUBETUI_CONFIG_HOME variable to set a directory")
+                .expect("no config dir, set YOUTUBETUI_CONFIG_HOME to override")
+                .join("youtube-tui")
         })
-}
-
-/// Returns the base data directory, respecting XDG_DATA_HOME on all platforms.
-fn sys_data_base() -> PathBuf {
-    std::env::var("YOUTUBETUI_DATA_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::data_local_dir()
-                .expect("no data dir, set the YOUTUBETUI_DATA_HOME variable to set a directory")
-        })
-}
-
-/// Returns the base cache directory, respecting XDG_CACHE_HOME on all platforms.
-fn sys_cache_base() -> PathBuf {
-    std::env::var("YOUTUBETUI_CACHE_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::cache_dir()
-                .expect("no cache dir, set the YOUTUBETUI_CACHE_HOME variable to set a directory")
-        })
-}
-
-/// Returns the base cache directory, respecting XDG_CACHE_HOME on all platforms.
-fn sys_download_base() -> PathBuf {
-    std::env::var("YOUTUBETUI_DOWNLOAD_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::cache_dir().expect(
-                "no cache dir, set the YOUTUBETUI_DOWNLOAD_HOME variable to set a directory",
-            )
-        })
-}
-
-/// Returns the configuration directory for youtube-tui.
-///
-/// Respects `XDG_CONFIG_HOME` on all platforms. Platform defaults:
-/// - Linux:   `~/.config/youtube-tui/`
-/// - Windows: `%APPDATA%\youtube-tui\`   (or `~/.config/youtube-tui/` if XDG_CONFIG_HOME is set)
-/// - macOS:   `~/Library/Application Support/youtube-tui/`
-pub fn config_dir() -> PathBuf {
-    sys_config_base().join("youtube-tui")
 }
 
 /// Returns the data directory for youtube-tui.
 ///
-/// Respects `XDG_DATA_HOME` on all platforms. Platform defaults:
+/// If `YOUTUBETUI_DATA_HOME` is set, it is used directly as the data directory.
+/// Otherwise falls back to the platform default with a `youtube-tui` subdirectory:
 /// - Linux:   `~/.local/share/youtube-tui/`
 /// - Windows: `%LOCALAPPDATA%\youtube-tui\`
 /// - macOS:   `~/Library/Application Support/youtube-tui/`
 pub fn data_dir() -> PathBuf {
-    sys_data_base().join("youtube-tui")
+    std::env::var("YOUTUBETUI_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::data_local_dir()
+                .expect("no data dir, set YOUTUBETUI_DATA_HOME to override")
+                .join("youtube-tui")
+        })
 }
 
 /// Returns the cache directory for youtube-tui.
 ///
-/// Respects `XDG_CACHE_HOME` on all platforms. Platform defaults:
+/// If `YOUTUBETUI_CACHE_HOME` is set, it is used directly as the cache directory.
+/// Otherwise falls back to the platform default with a `youtube-tui` subdirectory:
 /// - Linux:   `~/.cache/youtube-tui/`
 /// - Windows: `%LOCALAPPDATA%\youtube-tui\cache\`
 /// - macOS:   `~/Library/Caches/youtube-tui/`
 pub fn cache_dir() -> PathBuf {
-    sys_cache_base().join("youtube-tui")
+    std::env::var("YOUTUBETUI_CACHE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::cache_dir()
+                .expect("no cache dir, set YOUTUBETUI_CACHE_HOME to override")
+                .join("youtube-tui")
+        })
 }
 
 /// Returns the storage directory for rustypipe.
 ///
-/// Respects `XDG_DATA_HOME` on all platforms.
+/// Uses the parent of `YOUTUBETUI_DATA_HOME` (sibling to the youtube-tui data dir) if set,
+/// otherwise falls back to the platform data dir with a `rustypipe` subdirectory.
 pub fn rustypipe_dir() -> PathBuf {
-    sys_data_base().join("rustypipe")
+    std::env::var("YOUTUBETUI_DATA_HOME")
+        .map(|p| {
+            let base = PathBuf::from(p);
+            let parent = base.parent().map(|p| p.to_path_buf()).unwrap_or(base);
+            parent.join("rustypipe")
+        })
+        .unwrap_or_else(|_| {
+            dirs::data_local_dir()
+                .expect("no data dir, set YOUTUBETUI_DATA_HOME to override")
+                .join("rustypipe")
+        })
 }
 
 /// Returns the default save path string for the `save-path` env variable.
@@ -93,8 +80,15 @@ pub fn default_save_path() -> String {
 }
 
 /// Returns the default download path string for the `download-path` env variable.
+///
+/// If `YOUTUBETUI_DOWNLOAD_HOME` is set, it is used directly as the download directory.
+/// Otherwise falls back to the platform downloads directory.
 pub fn default_download_path() -> String {
-    let downloads = sys_download_base();
+    let downloads = std::env::var("YOUTUBETUI_DOWNLOAD_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::download_dir().expect("no download dir, set YOUTUBETUI_DOWNLOAD_HOME to override")
+        });
     let mut s = downloads.to_string_lossy().to_string();
     if !s.ends_with(std::path::MAIN_SEPARATOR) {
         s.push(std::path::MAIN_SEPARATOR);

--- a/src/global/functions/paths.rs
+++ b/src/global/functions/paths.rs
@@ -5,30 +5,43 @@ use std::path::PathBuf;
 /// On Linux this is handled by `dirs` already. On Windows and macOS, `dirs`
 /// ignores XDG env vars, so we check manually first. This lets Windows users
 /// keep their config in `~/.config` by setting `XDG_CONFIG_HOME`.
-fn xdg_config_base() -> PathBuf {
-    std::env::var("XDG_CONFIG_HOME")
+fn sys_config_base() -> PathBuf {
+    std::env::var("YOUTUBETUI_CONFIG_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
-            dirs::config_dir().unwrap_or_else(|| home::home_dir().unwrap().join(".config"))
+            dirs::config_dir()
+                .expect("no config dir, set the YOUTUBETUI_CONFIG_HOME variable to set a directory")
         })
 }
 
 /// Returns the base data directory, respecting XDG_DATA_HOME on all platforms.
-fn xdg_data_base() -> PathBuf {
-    std::env::var("XDG_DATA_HOME")
+fn sys_data_base() -> PathBuf {
+    std::env::var("YOUTUBETUI_DATA_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
             dirs::data_local_dir()
-                .unwrap_or_else(|| home::home_dir().unwrap().join(".local").join("share"))
+                .expect("no data dir, set the YOUTUBETUI_DATA_HOME variable to set a directory")
         })
 }
 
 /// Returns the base cache directory, respecting XDG_CACHE_HOME on all platforms.
-fn xdg_cache_base() -> PathBuf {
-    std::env::var("XDG_CACHE_HOME")
+fn sys_cache_base() -> PathBuf {
+    std::env::var("YOUTUBETUI_CACHE_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
-            dirs::cache_dir().unwrap_or_else(|| home::home_dir().unwrap().join(".cache"))
+            dirs::cache_dir()
+                .expect("no cache dir, set the YOUTUBETUI_CACHE_HOME variable to set a directory")
+        })
+}
+
+/// Returns the base cache directory, respecting XDG_CACHE_HOME on all platforms.
+fn sys_download_base() -> PathBuf {
+    std::env::var("YOUTUBETUI_DOWNLOAD_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::cache_dir().expect(
+                "no cache dir, set the YOUTUBETUI_DOWNLOAD_HOME variable to set a directory",
+            )
         })
 }
 
@@ -39,7 +52,7 @@ fn xdg_cache_base() -> PathBuf {
 /// - Windows: `%APPDATA%\youtube-tui\`   (or `~/.config/youtube-tui/` if XDG_CONFIG_HOME is set)
 /// - macOS:   `~/Library/Application Support/youtube-tui/`
 pub fn config_dir() -> PathBuf {
-    xdg_config_base().join("youtube-tui")
+    sys_config_base().join("youtube-tui")
 }
 
 /// Returns the data directory for youtube-tui.
@@ -49,7 +62,7 @@ pub fn config_dir() -> PathBuf {
 /// - Windows: `%LOCALAPPDATA%\youtube-tui\`
 /// - macOS:   `~/Library/Application Support/youtube-tui/`
 pub fn data_dir() -> PathBuf {
-    xdg_data_base().join("youtube-tui")
+    sys_data_base().join("youtube-tui")
 }
 
 /// Returns the cache directory for youtube-tui.
@@ -59,14 +72,14 @@ pub fn data_dir() -> PathBuf {
 /// - Windows: `%LOCALAPPDATA%\youtube-tui\cache\`
 /// - macOS:   `~/Library/Caches/youtube-tui/`
 pub fn cache_dir() -> PathBuf {
-    xdg_cache_base().join("youtube-tui")
+    sys_cache_base().join("youtube-tui")
 }
 
 /// Returns the storage directory for rustypipe.
 ///
 /// Respects `XDG_DATA_HOME` on all platforms.
 pub fn rustypipe_dir() -> PathBuf {
-    xdg_data_base().join("rustypipe")
+    sys_data_base().join("rustypipe")
 }
 
 /// Returns the default save path string for the `save-path` env variable.
@@ -81,8 +94,7 @@ pub fn default_save_path() -> String {
 
 /// Returns the default download path string for the `download-path` env variable.
 pub fn default_download_path() -> String {
-    let downloads =
-        dirs::download_dir().unwrap_or_else(|| home::home_dir().unwrap().join("Downloads"));
+    let downloads = sys_download_base();
     let mut s = downloads.to_string_lossy().to_string();
     if !s.ends_with(std::path::MAIN_SEPARATOR) {
         s.push(std::path::MAIN_SEPARATOR);


### PR DESCRIPTION
The dirs crate honours XDG env vars on Linux but ignores them on
Windows and macOS. This change checks the XDG vars manually before
falling back to dirs, so users on any platform can override the
default locations by setting the standard XDG environment variables.

Practical use on Windows: set XDG_CONFIG_HOME=~\.config to keep
config files in the same location as a Linux install.
