### PR TITLE
ci: Add GitHub Action to upload vendor tarball on release

### DIFF
--- a/.github/workflows/release-crates-tarball.yml
+++ b/.github/workflows/release-crates-tarball.yml
@@ -1,0 +1,29 @@
+name: "Release Crates Tarball"
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release-tarball:
+    name: Generate and Upload Vendor Tarball
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Vendor Dependencies
+        run: |
+          # Generate the vendor directory
+          cargo vendor
+          # Archive it into a tarball
+          tar -cJf youtube-tui-${{ github.ref_name }}-crates.tar.xz vendor/
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: youtube-tui-${{ github.ref_name }}-crates.tar.xz


### PR DESCRIPTION
### Description

This PR adds a GitHub Action that automatically generates and uploads a vendored dependencies tarball (`youtube-tui-<tag>-crates.tar.xz`) to the GitHub Releases page whenever a new version tag (`v*`) is pushed.

### Why is this needed?

When packaging Rust applications for Linux distributions (like Gentoo, Alpine, Void, NixOS, etc.), the build environment is almost always strictly sandboxed and stripped of network access to enforce reproducible builds. 

Because `cargo build` cannot fetch crates from `crates.io` during an offline package build, distribution maintainers have to either manually extract and list hundreds of individual crate download URLs in their package scripts, or provide a single `vendor` tarball.

By automating the creation of this vendored tarball and attaching it directly to the official upstream releases, you make packaging `youtube-tui` for all Linux distributions significantly easier and more maintainable.

### Changes
* Created `.github/workflows/release-crates-tarball.yml` which triggers on new `v*` tags.
* It checks out the repo, installs Rust, runs `cargo vendor`, archives the directory into an `xz` tarball, and uses `softprops/action-gh-release` to attach it to the release.